### PR TITLE
Add a Nano installer for Windows

### DIFF
--- a/setup/bin/swc-nano-installer.py
+++ b/setup/bin/swc-nano-installer.py
@@ -64,7 +64,6 @@ def make_posix_path(windows_path):
 def main():
     home_dir = os.path.expanduser("~")
     nano_dir = os.path.join(home_dir, '.nano')
-    #home_dir = "/home/ethan/swc-nano-test"
     if not os.path.exists(nano_dir):
         os.makedirs(nano_dir)
     install_nano(nano_dir)


### PR DESCRIPTION
Based on discussions here:
http://lists.software-carpentry.org/pipermail/tutors_lists.software-carpentry.org/2013-September/000934.html

It seems like it would be useful to have a Nano installer for Windows users. This is my attempt. It does the following:
1. Downloads and installs Nano into the user's home directory
2. Adds Nano to the path
3. Makes Nano the default editor

This has been tested on a single Windows 7 machine.
