### PR TITLE
Replace Python with Shell

### DIFF
--- a/_includes/guide-shell/scripts/lesson.html
+++ b/_includes/guide-shell/scripts/lesson.html
@@ -42,7 +42,7 @@ head -20 cholesterol.pdb | tail -5
       headings,
       and so on.
       This extra information isn't stored as characters,
-      and doesn't mean anything to the Shell interpreter:
+      and doesn't mean anything to the shell interpreter:
       it expects input files to contain nothing but the letters, digits, and punctuation
       on a standard computer keyboard.
       When editing programs,


### PR DESCRIPTION
In the box "Text vs. Whatever" it say Python when should say
Shell.

I also move this box two paragraphs up to be closer of the lesson
part about writing the file `middle.sh`.
