### PR TITLE
Add editor for GNU/Linux in swc-git

### DIFF
--- a/lessons/swc-git/tutorial.md
+++ b/lessons/swc-git/tutorial.md
@@ -123,7 +123,7 @@ and that we want it to colorize output.
 There are a few more configuration variables to set depending on your OS. First, 
 choose a text editor. We recommend that novices use [GNU
 nano](http://en.wikipedia.org/wiki/GNU_nano) because it's easy to use and
-work in most operating systems. Some other options
+works in most operating systems. Some other options
 might be TextEdit on the Mac, gedit on GNU/Linux or Notepad on Windows. The
 default on many systems is vi, which is not a friendly text editor for beginners.
 If they've installed a better editor for the workshop, use that instead.


### PR DESCRIPTION
AFAIK textedit isn't include in all GNU/Linux distribution.
I add gedit as the GNU/Linux text editor.

I change the order of the configure commands to be the same of
present in the text.
