### PR TITLE
Cite shell parameter expansion

### DIFF
--- a/_includes/guide-shell/loop/lesson.html
+++ b/_includes/guide-shell/loop/lesson.html
@@ -65,7 +65,7 @@ UPDATED: 1738-11-24</span>
     is assigned to the <a href="glossary.html#variable">variable</a> <code>filename</code>.
     Inside the loop,
     we get the variable's value by putting <code>$</code> in front of it
-    (this is know as shell parameter expansion),
+    (this is known as shell parameter expansion),
     so the first time through the loop,
     <code>$filename</code> is <code>basilisk.dat</code>,
     and the second time,
@@ -94,7 +94,7 @@ UPDATED: 1738-11-24</span>
       We have called the variable in this loop <code>filename</code>
       in order to make its purpose clearer to human readers.
       The shell itself doesn't care what the variable is called
-      (but when we use the variable value is a good practice use
+      (but when we use the variable value it is a good practice to use
       <code>${filename}</code> instead of <code>$filename</code> to avoid
       some types of problems);
       if we wrote this loop as:


### PR DESCRIPTION
This is part of Issue #54.

In this commit we mention the shell parameter expansion to make
easy to students go deep if they need.

We also add a note about use ${some-var} instead of $some-var.
