### PR TITLE
Addressed subtle variable reference error.

### DIFF
--- a/lessons/swc-python/python-01-functions.ipynb
+++ b/lessons/swc-python/python-01-functions.ipynb
@@ -430,10 +430,11 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "`fahr_to_kelvin`'s `temp` is *not* the same variable as `fahr_to_celsius`'s `temp`.\n",
-      "The two variables happen to have the same name,\n",
-      "but since they're in different stack frames,\n",
-      "they're as different as Einstein's glasses and Feynman's glasses."
+      "`fahr_to_kelvin`'s `temp` is **not** the same variable as `fahr_to_celsius`'s `temp`.\n",
+      "The two variables have the same names, but because they're in different\n",
+      "stack frames, they're different variables. In this case, they happen to\n",
+      "reference the same object, but that is not because their names are the\n",
+      "same."
      ]
     },
     {


### PR DESCRIPTION
This slightly improves the text in the SWC notebook by strengthening the
idea that Python variables reference objects, not data.

This commit fixes GitHub Issue #61.
