### PR TITLE
Added make links target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ clean :
 	rm -rf _site $$(find . -name '*~' -print)
 
 ## links      : check links
+# depends on linklint, an html-link-checking module from http://www.linklint.org/
+
 links :
 	@linklint -doc /tmp/linkdoc -root _site /@
 


### PR DESCRIPTION
This adds the links target to `Makefile` for the convenience of developers looking for broken http links in the website.

This invokes [linklint](http://www.linklint.org/).
