### PR TITLE
Trying to teach nbconvert to make pages from our notebooks, but tripping over Unicode characters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ NOTEBOOK_SRC = \
 	$(wildcard python/novice/*.ipynb) \
 	$(wildcard sql/novice/*.ipynb)
 NOTEBOOK_DST = \
-	$(patsubst %.ipynb,$(OUT)/%.html,$(NOTEBOOK_SRC))
+	$(patsubst %,$(OUT)/%.html,$(NOTEBOOK_SRC))
 
 #-----------------------------------------------------------
 
@@ -19,9 +19,17 @@ all : commands
 commands :
 	@grep -E '^##' Makefile | sed -e 's/## //g'
 
-## check    : build locally into $(OUT) directory for checking
+## check    : build notebooks *after* Jekyll runs, because it wipes the output directory.
 check : $(NOTEBOOK_DST)
+
+$(NOTEBOOK_DST) : $(OUT)/README.md
+
+$(OUT)/README.md :
 	jekyll -t build -d $(OUT)
+
+$(OUT)/%.ipynb.html : %.ipynb
+	@mkdir -p $$(dirname $@)
+	ipython nbconvert --output="$(OUT)/$<" "$<"
 
 ## clean    : clean up
 clean :
@@ -31,10 +39,3 @@ clean :
 show :
 	@echo "NOTEBOOK_SRC" $(NOTEBOOK_SRC)
 	@echo "NOTEBOOK_DST" $(NOTEBOOK_DST)
-
-#-----------------------------------------------------------
-
-# rule to make HTML pages from notebook files.
-$(OUT)/%.html : %.ipynb
-	@mkdir -p $$(dirname $@)
-	ipython nbconvert --stdout $< > $@


### PR DESCRIPTION
The Makefile is trying to do the right thing, but characters like `&times;` in the HTML get converted to u'\xd7', which then produce the stack trace below. If anyone knows the magic words, please let me know.  (Storing the `×` character directly in the notebook doesn't work either.)

```
Traceback (most recent call last):
  File "/Users/gwilson/anaconda/bin/ipython", line 6, in <module>
    sys.exit(start_ipython())
  File "/Users/gwilson/anaconda/lib/python2.7/site-packages/IPython/__init__.py", line 118, in start_ipython
    return launch_new_instance(argv=argv, **kwargs)
  File "/Users/gwilson/anaconda/lib/python2.7/site-packages/IPython/config/application.py", line 539, in launch_instance
    app.start()
  File "/Users/gwilson/anaconda/lib/python2.7/site-packages/IPython/terminal/ipapp.py", line 356, in start
    return self.subapp.start()
  File "/Users/gwilson/anaconda/lib/python2.7/site-packages/IPython/nbconvert/nbconvertapp.py", line 266, in start
    self.convert_notebooks()
  File "/Users/gwilson/anaconda/lib/python2.7/site-packages/IPython/nbconvert/nbconvertapp.py", line 305, in convert_notebooks
    write_resultes = self.writer.write(output, resources, notebook_name=notebook_name)
  File "/Users/gwilson/anaconda/lib/python2.7/site-packages/IPython/nbconvert/writers/stdout.py", line 34, in write
    print(output)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xd7' in position 212734: ordinal not in range(128)
```
