### PR TITLE
Changed links to thw materials to nbviewer renderings of the notebooks

### DIFF
--- a/lessons/index.html
+++ b/lessons/index.html
@@ -2,6 +2,8 @@
 layout: lesson
 root: ..
 title: Lesson Material
+ipythonnotebook: http://nbviewer.ipython.org/urls
+raw: raw.github.com/swcarpentry/bc/gh-pages
 ---
 
 <p>
@@ -132,7 +134,7 @@ title: Lesson Material
       as modified by Joshua R. Smith and Sri Hari Krishna Narayanan.
       It includes:
       <ul>
-	<li><a href="thw-git/instructors.html">Instructors' Guide</a></li>
+<!--	<li><a href="thw-git/instructors.html">Instructors' Guide</a></li> -->
 	<li><a href="thw-git/local.html">Local Operations</a></li>
 	<li><a href="thw-git/remote.html">Using Remote Repositories</a></li>
       </ul>
@@ -143,11 +145,11 @@ title: Lesson Material
       An introduction to the basic features of Python,
       which covers:
       <ul>
-	<li><a href="thw-python/vars-types/tutorial.html">Variables and Types</a></li>
-	<li><a href="thw-python/flow-control/tutorial.html">Flow Control</a></li>
-	<li><a href="thw-python/data-structures/tutorial.html">Data Structures</a></li>
-	<li><a href="thw-python/strings-io/tutorial.html">Strings and File I/O</a></li>
-	<li><a href="thw-python/functions-modules/tutorial.html">Functions and Modules</a></li>
+	<li><a href="{{page.ipythonnotebook}}/{{page.raw}}/lessons/thw-python/vars-types/variables.ipynb">Variables and Types</a></li>
+	<li><a href="{{page.ipythonnotebook}}/{{page.raw}}/lessons/thw-python/data-structures/data_structures.ipynb">Data Structures</a></li>
+	<li><a href="{{page.ipythonnotebook}}/{{page.raw}}/lessons/thw-python/flow-control/python_flow_control.ipynb">Flow Control</a></li>
+	<li><a href="{{page.ipythonnotebook}}/{{page.raw}}/lessons/thw-python/strings-io/tutorial.ipynb">Strings and File I/O</a></li>
+	<li><a href="{{page.ipythonnotebook}}/{{page.raw}}/lessons/thw-python/functions-and-modules/python_functions_and_modules.ipynb">Functions and Modules</a></li>
       </ul>
       Most sections also include some exercise material.
     </dd>
@@ -156,20 +158,20 @@ title: Lesson Material
     <dd>
       This introduction is based on materials
       originally written by Anthony Scopatz and Patrick Fuller.
-      It includes a <a href="thw-python-debugging/tutorial.html">single tutorial</a>.
+      It includes a <a href="{{page.ipythonnotebook}}/{{page.raw}}/lessons/thw-python-debugging/tutorial.ipynb">notebook</a>.
     </dd>
 
     <dt>Testing with Python</dt>
     <dd>
       This introduction is based on materials
       originally written by Katy Huff, Rachel Slaybaugh, and Anthony Scopatz.
-      It includes a <a href="thw-testing/tutorial.html">single tutorial</a>.
+      It includes a <a href="{{page.ipythonnotebook}}/{{page.raw}}/lessons/thw-testing/tutorial.ipynb">notebook</a>.
     </dd>
 
     <dt>NumPy</dt>
     <dd>
       An introduction to array-based computing in Python from Matthew Terry.
-      It consists of a <a href="thw-numpy/tutorial.html">single tutorial</a>.
+      It consists of a <a href="{{page.ipythonnotebook}}/{{page.raw}}/lessons/thw-numpy/numpy.ipynb">notebook</a>.
     </dd>
 
     <dt>SciPy</dt>
@@ -182,13 +184,13 @@ title: Lesson Material
     <dd>
       An introduction to plotting in Python using matplotlib
       originally written by Anthony Scopatz and Katy Huff.
-      It consists of a <a href="thw-matplotlib/tutorial.html">single tutorial</a>.
+      It consists of a <a href="{{page.ipythonnotebook}}/{{page.raw}}/lessons/thw-matplotlib/matplotlib-instructor.ipynb">notebook</a>.
     </dd>
 
     <dt>Documentation</dt>
     <dd>
       An introduction to documenting code from Anthony Scopatz.
-      It consists of a <a href="thw-matplotlib/tutorial.html">single tutorial</a>.
+      It consists of a <a href="{{page.ipythonnotebook}}/{{page.raw}}/lessons/thw-documentation/tutorial.ipynb">notebook</a>.
     </dd>
 
   </dl>


### PR DESCRIPTION
Issue #106 seeks to remove obsolete markdown formatted duplicates of lessons that are now maintained in ipython notebook.

This pull request replaces links to jekyll-generated html that will break when those markdown files are removed to ipython notebook renderings of the notebooks.  
