### PR TITLE
Removing the box around "R" in the title of the setup overview for R.

### DIFF
--- a/_includes/setup/overview-r.html
+++ b/_includes/setup/overview-r.html
@@ -1,5 +1,5 @@
 <div id="setup-overview-r" class="setup setup-r">
-  <h3 class="well well-small">R</h3>
+  <h3>R</h3>
 
   <p>
     R is a programming language that specializes in statistical


### PR DESCRIPTION
The header shows up with a box around "R", which does not appear in the headers for the rest of the overviews. This commit removes the box.
