### PR TITLE
Changing the word "boot camp" to "bootcamp" in all *.md and *.hmtml file...

### DIFF
--- a/_includes/bootcamps/python.html
+++ b/_includes/bootcamps/python.html
@@ -1,5 +1,5 @@
 <p>
-  <strong>Content:</strong> The syllabus for this boot camp will include:
+  <strong>Content:</strong> The syllabus for this bootcamp will include:
 </p>
 <ul>
   <li>using the shell to do more in less time</li>

--- a/_includes/bootcamps/r.html
+++ b/_includes/bootcamps/r.html
@@ -1,5 +1,5 @@
 <p>
-  <strong>Content:</strong> The syllabus for this boot camp will include:
+  <strong>Content:</strong> The syllabus for this bootcamp will include:
 </p>
 <ul>
   <li>using the shell to do more in less time</li>

--- a/_includes/bootcamps/requirements.html
+++ b/_includes/bootcamps/requirements.html
@@ -2,5 +2,5 @@
   <strong>Requirements:</strong>
   Participants must bring a laptop with a few specific software
   packages installed. (The list will be sent to participants a week
-  before the boot camp.)
+  before the bootcamp.)
 </p>

--- a/_includes/bootcamps/what.html
+++ b/_includes/bootcamps/what.html
@@ -2,7 +2,7 @@
   <strong>What:</strong>
   Our goal is to help scientists and engineers become more productive
   by teaching them basic computing skills like program design, version
-  control, testing, and task automation. In this two-day boot camp,
+  control, testing, and task automation. In this two-day bootcamp,
   short tutorials will alternate with hands-on practical
   exercises. Participants will be encouraged both to help one another,
   and to apply what they have learned to their own research problems

--- a/_includes/guide-invperc/instructors.html
+++ b/_includes/guide-invperc/instructors.html
@@ -2,7 +2,7 @@
 
   <p>
     I have never gotten as far as this lesson
-    in a two-day boot camp aimed at novices,
+    in a two-day bootcamp aimed at novices,
     but I have frequently used it in week-long classes,
     or in classes aimed at more experienced learners.
     It has everything we want in an extended example:

--- a/_includes/people/blischak.j.html
+++ b/_includes/people/blischak.j.html
@@ -5,7 +5,7 @@
     the University of Chicago. His research focuses on the
     transcriptional response of human macrophages to infection
     by <em>Mycobacterium tuberculosis</em>. He greatly benefited from
-    attending a Software Carpentry boot camp and enjoys passing along
+    attending a Software Carpentry bootcamp and enjoys passing along
     these useful skills to other scientists.
   </div>
 </div>

--- a/_includes/setup/windows-mercurial.html
+++ b/_includes/setup/windows-mercurial.html
@@ -5,7 +5,7 @@
       Download and install <a href="http://mercurial.selenic.com/downloads/">Mercurial</a>.
     </li>
     <li>
-      If your boot camp is using EasyMercurial,
+      If your bootcamp is using EasyMercurial,
       <a href="http://easyhg.org/download.html">download</a> and install it.
     </li>
   </ul>

--- a/lessons/misc-git/git-and-github/instructor_notes.md
+++ b/lessons/misc-git/git-and-github/instructor_notes.md
@@ -101,7 +101,7 @@ collaboration.
 ### Previewing Changes
 
 - The file we're making is going to be a list of the top things everyone wants
-  to learn in the boot camp. Add your item (e.g. everyone's names) and save.
+  to learn in the bootcamp. Add your item (e.g. everyone's names) and save.
 - `git status` -- point out that now we have a modified file instead of an
   untracked file, but the procedure for adding it to the next snapshot is
   the same.

--- a/lessons/misc-r/tutorial.md
+++ b/lessons/misc-r/tutorial.md
@@ -3,12 +3,12 @@ layout: lesson
 root: ../..
 title: Introduction to R
 ---
-This repository gives the R content from Duke software Carpentry May 20 - 21 2013, which was very similar to the NESCent boot camp which ran May 17 - 18,2013.
+This repository gives the R content from Duke software Carpentry May 20 - 21 2013, which was very similar to the NESCent bootcamp which ran May 17 - 18,2013.
 
 Here are pages with set-up instructions, etc.:
 
-*   [NESCent boot camp](http://swcarpentry.github.io/bootcamps/2013-05-16-nescent/)
-*   [Duke boot camp](http://swcarpentry.github.io/bootcamps/2013-05-20-duke/)
+*   [NESCent bootcamp](http://swcarpentry.github.io/bootcamps/2013-05-16-nescent/)
+*   [Duke bootcamp](http://swcarpentry.github.io/bootcamps/2013-05-20-duke/)
 
 Day 1 was essentially all R, using RStudio. Main instructor Jenny Bryan. At the end of the day, we had some input data (an excerpt from the Gapminder data), several R scripts, and various outputs that these scripts left behind, e.g. figures, numerical results, analytical reports. The first commit to this repo is a snapshot of where we are at the end of Day 1. The README.md associated with the `code` subdirectory explains what each file does.
 

--- a/lessons/thw-shell/tutorial.ipynb
+++ b/lessons/thw-shell/tutorial.ipynb
@@ -197,7 +197,7 @@
       "is an executable. If you use `ls -F` you will see that this file ends\n",
       "with a star.\n",
       "\n",
-      "This directory contains all of the material for this boot camp. Now\n",
+      "This directory contains all of the material for this bootcamp. Now\n",
       "move to the directory containing the data for the shell tutorial:\n",
       "\n",
       "    cd data\n",

--- a/lessons/thw-shell/tutorial.md
+++ b/lessons/thw-shell/tutorial.md
@@ -150,7 +150,7 @@ will see that there is an entry which is green. This means that this
 is an executable. If you use `ls -F` you will see that this file ends
 with a star.
 
-This directory contains all of the material for this boot camp. Now
+This directory contains all of the material for this bootcamp. Now
 move to the directory containing the data for the shell tutorial:
 
     cd shell

--- a/setup/README.md
+++ b/setup/README.md
@@ -8,7 +8,7 @@ Students
 ========
 
 This directory contains scripts for testing your machine to make sure
-you have the software you'll need for your boot camp installed.  See
+you have the software you'll need for your bootcamp installed.  See
 the comments at the head of each script for more details, but you'll
 basically want to see something like:
 
@@ -60,16 +60,16 @@ they'll be able to parse `swc-installation-test-2.py`.  The latter
 checks for a list of dependencies and prints error messages if a
 package is not installed, or if the installed version is not current
 enough.  By default, the script checks for pretty much anything that
-has ever been used at a Software Carpentry boot camp, which is
-probably not what you want for your particular boot camp.
+has ever been used at a Software Carpentry bootcamp, which is
+probably not what you want for your particular bootcamp.
 
-Before your boot camp, you should go through
+Before your bootcamp, you should go through
 `swc-installation-test-2.py` and comment any dependencies you don't
 need out of the `CHECKS` list.  You might also want to skim through
 the minimum version numbers listed where particular dependencies are
 defined (e.g. `('git', 'Git', (1, 7, 0), None)`).  For the most part,
 fairly conservative values have been selected, so students with modern
-machines should be fine.  If your boot camp has stricter version
+machines should be fine.  If your bootcamp has stricter version
 requirements, feel free to bump them accordingly.
 
 Similarly, the virtual dependencies can be satisfied by any of several


### PR DESCRIPTION
... to fix issue #55.

I've just grep'd and sed'd "boot camp" to bootcamp. Now here's no "boot-camp", or "boot camp" in the text. No wrong plurals either.
