### PR TITLE
Fixing example explaining why people shouldn't use spaces in filenames

### DIFF
--- a/bash/novice/04-loop.md
+++ b/bash/novice/04-loop.md
@@ -127,28 +127,31 @@ the `head` and `tail` combination selects lines 81-100 from whatever file is bei
 > 
 >     for filename in *.dat
 >     do
->         echo $filename
 >         head -100 $filename | tail -20
 >     done
-> 
+>
 > then `*.dat` will expand to:
 > 
 >     basilisk.dat red dragon.dat unicorn.dat
 > 
-> which means that `filename` will be assigned each of the following
-> values in turn:
+> If we are using an older version of the Bash,
+> or some other shell,
+> `filename` will be assigned the following values in turn:
 > 
 >     basilisk.dat
 >     red
 >     dragon.dat
 >     unicorn.dat
 > 
-> The second and third lines show the problem: instead of getting one name
-> `red dragon.dat`, the commands in the loop will get `red` and
-> `dragon.dat` separately. To make matters worse, the file
-> `red dragon.dat` won't be processed at all. There are ways to get around
-> this, but the safest thing is to use dashes, underscores, or some other
-> printable character instead of spaces.
+> We can make our script a little bit more robust
+> by [quoting](../../gloss.html#shell-quoting) our use of the variable:
+> 
+>     for filename in *.dat
+>     do
+>         head -100 "$filename" | tail -20
+>     done
+>
+> but it's simpler just to avoid using spaces (or other special characters) in filenames.
 
 Going back to our original file renaming problem,
 we can solve it using this loop:

--- a/gloss.md
+++ b/gloss.md
@@ -130,6 +130,9 @@ Its name is "/" on Unix (including Linux and Mac OS X) and "\" on Microsoft Wind
 **shell script**: <a name="shell-script"></a>
 FIXME
 
+**shell quoting**: <a name="shell-quoting"></a>
+FIXME
+
 **standard input** (stdin): <a name="standard-input"></a>
 A process's default input stream.
 In interactive command-line applications,


### PR DESCRIPTION
Addresses #83.  (Some versions of Mac OS X are still running Bash 3.2.48 by default, so the original example holds; wording has been changed to "may".)
