### PR TITLE
swc-installation-test-2.py: Prefer pip to easy_install

### DIFF
--- a/setup/swc-installation-test-2.py
+++ b/setup/swc-installation-test-2.py
@@ -853,8 +853,8 @@ for name,long_name,dependencies in [
             'safari',
             )),
         ('virtual-pypi-installer', 'PyPI installer', (
-            'easy_install',
             'pip',
+            'easy_install',
             )),
         ]:
     CHECKER[name] = VirtualDependency(


### PR DESCRIPTION
For virtual-pypi-installer.  easy_install is part of Setuptools [1](http://pythonhosted.org/setuptools/), which was
dead for several years.  The Distribute fork took over, but has since been
merged back into a revitalized Setuptools (since Setuptools v0.7 [2](http://pythonhosted.org/distribute/), tagged
on 2013-06-02 [3](https://bitbucket.org/pypa/setuptools/commits/tag/0.7)).  Pip >= v1.4 actually requires a modern Setuptools, not
Distribute [4](http://www.pip-installer.org/en/latest/installing.html#id6).  Pip also improves on easy_install [5](http://www.pip-installer.org/en/latest/other-tools.html#easy-install), which does not
currently support uninstalling packages [6](http://pythonhosted.org/setuptools/easy_install.html#uninstalling-packages).
