### PR TITLE
Prefer `git init` and `git add -A .` to `git init .` and `git add -A`

### DIFF
--- a/git/novice/01-backup.md
+++ b/git/novice/01-backup.md
@@ -42,7 +42,7 @@ $ cd planets
 and tell Git to make it a [repository](../gloss.html#repository):
 
 ```
-$ git init .
+$ git init
 ```
 
 If we use `ls` to show the directory's contents,

--- a/git/novice/reference.md
+++ b/git/novice/reference.md
@@ -13,7 +13,7 @@ Set global configuration (only needs to be done once per machine):
 
 Initialize a directory as a repository:
 
-    git init .
+    git init
 
 Display the status of the repository:
 

--- a/lessons/swc-git/tutorial.md
+++ b/lessons/swc-git/tutorial.md
@@ -162,7 +162,7 @@ $ cd planets
 and tell Git to initialize it:
 
 ```
-$ git init .
+$ git init
 ```
 
 If we use `ls` to show the directory's contents,


### PR DESCRIPTION
Bring `git init` invocations in line with examples from the Git
documentation, and future-proof `git add` for Git v2.0.  More details
in the commit messages.  I'm also concerned about:

```
$ git push -u nickname master
```

vs.

```
$ git push nicname master
```

The former is explained as “Push changes from a local repository to a
remote (if `master` doesn't yet exist\ in the remote)”, but that's not
what the `-u` option actually does (it actually sets the upstream
branch, see `git push --help` for details).  I only use `-u` myself
when I'm setting up a branch for a hub pull-request ([1](https://github.com/github/hub#contributing) and [2](https://github.com/github/hub/blob/master/lib/hub/commands.rb#L179)).  I don't
think the distinction will be important to novice users.
