### PR TITLE
Fixed broken image link in 04-cond.ipynb

### DIFF
--- a/python/novice/04-cond.ipynb
+++ b/python/novice/04-cond.ipynb
@@ -151,7 +151,7 @@
       "every shade is some combination of red, green, and blue intensities.\n",
       "We can think of these three values as being the axes in a cube:\n",
       "\n",
-      "<img src=\"files/color-cube.png\" alt=\"RGB Color Cube\" />\n",
+      "<img src=\"files/img/color-cube.png\" alt=\"RGB Color Cube\" />\n",
       "\n",
       "An RGB color is an example of a multi-part value:\n",
       "like a Cartesian coordinate,\n",


### PR DESCRIPTION
I noticed a broken link to an image as I was perusing the novice python material, and here is a quick fix. 

Also, just out of curiosity, I'm a bit confused as to the full `src` string for all of the images in the various notebooks. There isn't an explicit `files` directory, yet all of the markup refers to it (all of the images reside in `./img` relative to the notebooks) . If someone could clarify the syntax in specifying the location of the image files, I'd appreciate it. 
