### PR TITLE
Add warning about Git commit id

### DIFF
--- a/git/novice/01-backup.md
+++ b/git/novice/01-backup.md
@@ -145,7 +145,9 @@ $ git commit -m "Starting to think about Mars"
 When we run `git commit`,
 Git takes everything we have told it to save using `git add`
 and stores a copy permanently inside the special `.git` directory.
-This permanent copy is called a [revision](../../gloss.html#revision).
+This permanent copy is called a [revision](../../gloss.html#revision)
+and in this case it is identify by `f22b25e` (your revision will
+have another identifier).
 We use the `-m` flag (for "message")
 to record a comment that will help us remember later on what we did and why.
 If we just run `git commit` without the `-m` option,


### PR DESCRIPTION
User starting use git after a bash lesson can expect to have
the same output in the terminal but it will not happen due the
commit id.

This commit add a very short note about this possible issue.
