### PR TITLE
Add note about argparse

### DIFF
--- a/python/novice/06-cmdline.ipynb
+++ b/python/novice/06-cmdline.ipynb
@@ -929,6 +929,16 @@
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Python has a module named [argparse](http://docs.python.org/dev/library/argparse.html)\n",
+      "that helps handle complex command-line flags. We will not cover this module in this lesson\n",
+      "but you can go to Tshepang Lekhonkhobe's [Argparse tutorial](http://docs.python.org/dev/howto/argparse.html)\n",
+      "that is part of Python's Official Documentation."
+     ]
+    },
+    {
+     "cell_type": "markdown",
      "metadata": {
       "cell_tags": [
        "challenges"


### PR DESCRIPTION
argparse is a Python module to help writing command-line argument.

In #247 we agree that SWC should not teach argparse but can
mention it.
