### PR TITLE
lessons/ref/shell.html: Drop the [!...] POSIX shell syntax

### DIFF
--- a/_includes/guide-shell/wildcard/keypoints.html
+++ b/_includes/guide-shell/wildcard/keypoints.html
@@ -4,7 +4,6 @@
     <li><code>*</code> is a wildcard pattern that matches zero or more characters in a pathname.</li>
     <li><code>?</code> is a wildcard pattern that matches any single character.</li>
     <li><code>[]</code> and <code>{}</code> allow you to match specified sets of characters in different ways.</li>
-    <li><code>[!<em>characters</em>]</code> matches everything <em>other than</em> the characters specified.</li>
     <li>Wildcards are useful when performing actions on more than one
     file at a time.</li>
     <li>The shell matches wildcards before running commands.</li>

--- a/_includes/guide-shell/wildcard/lesson.html
+++ b/_includes/guide-shell/wildcard/lesson.html
@@ -82,19 +82,6 @@ $
       <code>text1.txt</code>, 
       <code>text2.txt</code>, ...,
       <code>text6.txt</code>.</li>
-    <li>The <b>exclamation mark, <code>!</code></b>, which can be used
-      with square brackets to negate characters.  For example,
-      <code>text[!135].txt</code> would match anything of the form
-      <code>text?.txt</code> <em>except</em> for
-      <code>text1.txt</code>,
-      <code>text3.txt</code>, and
-      <code>text5.txt</code>.
-      (Note that the exclamation mark has to be used right after
-      the first square bracket as in the example.  An exclamation
-      mark outside of square brackets is not a wildcard, but
-      serves another function of
-      accessing previous commands from your history, as we will
-      later see.)</li>
     <li>The <b>curly braces, <code>{}</code></b>, are similar to the square
       brackets, except that they take a list of items separated by
       commas, and that they always expand all elements of the list,
@@ -189,26 +176,6 @@ $ <span class="in">ls file??.txt</span>
 $
 </pre>
 
-  <p>
-    Let's try out using the <code>!</code> wildcard with square brackets. 
-    The pattern <code>file[!46]*</code> would match everything beginning with 
-    "file", <em>unless</em> the next character is a 4 or a 6.  Thus, 
-    continuing with our example, if we do <code>rm file[!46]*</code>, we 
-    will delete everything except <code>file4.txt</code> and 
-    <code>file6.txt</code>:
-  </p>
-
-<pre>
-$ <span class="in">ls</span>
-<span class="out">file4.txt   file7.txt    file_b.txt   file_d.txt</span>
-<span class="out">file6.txt   file_a.txt   file_c.txt   file_e.txt</span>
-$ <span class="in">rm file[!46]*</span>
-$ <span class="in">ls</span>
-<span class="out">file4.txt   file6.txt</span>
-$
-</pre>
-
-  <p>
     It's also possible to combine and nest wildcards.  For example, 
     <code>file{4,_?}.txt</code> would match <code>file4.txt</code> 
     and <code>file_?.txt</code>, where <code>?</code> matches any 

--- a/lessons/ref/shell.html
+++ b/lessons/ref/shell.html
@@ -89,14 +89,6 @@ title: Shell Reference
 	<td>exactly one character in the given range</td>
       </tr>
       <tr>
-	<td><code>[!abcde]</code></td>
-	<td>any character not listed</td>
-      </tr>
-      <tr>
-	<td><code>[!a-e]</code></td>
-	<td>any character that is not in the given range</td>
-      </tr>
-      <tr>
 	<td><code>{software,carpentry}</code></td>
 	<td>exactly one entire word from the options given</td>
       </tr>


### PR DESCRIPTION
I was surprised by this so I looked it up.  It turns out that the
POSIX shell does indeed buck the standard RE syntax [1] by changing
from a circumflex (^) to an exclamation point (!) [2].  As far as
POSIX is concerned, '[^...]' is undefined. Luckily for me, Bash
accepts both forms (see the "Pattern Matching" section of bash(1)). Is
it worth mentioning this gotcha for folks using other regex parsers or
shells?

On Tue, Nov 12, 2013 at 12:13:31PM -0800, Greg Wilson wrote:

> On 2013-11-12 3:12 PM, W. Trevor King wrote:
> 
> > On Tue, Nov 12, 2013 at 11:38:38AM -0800, Aron Ahmadia wrote:
> > 
> > > My inclination is just to teach folks the `^` version since it
> > > is recognized by Bash and less confusing for learners going on
> > > to regular expressions, which are hard enough already.
> > 
> > If we get this deep into shell regex patterns, that's fine with
> > me. I think we should just introduce *, and move on to stuff we
> > care more strongly about like version control, testing, and
> > modular design.  Unless the students are asking for regex
> > instruction explicitly, but I'm not sure how often that happens.
> 
> I usually just do \* and ? --- I'll amend the lesson accordingly.

This commit fixes the examples turned up by:

```
$ git grep '\[\!' | grep -v '\(png\|pdf\|jpg\|odg\) matches'
```

See #137 and #145 for earlier discussion.  This material predates the
`{tool}/{level}` restructuring, so I don't know if anyone's using it
anymore.  If this material is a dead end, I'll drop this PR (and add a
new one removing the cruft ;).  If this material is not a dead end, I
think this PR would be useful.

[1]:
http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_13_01
[2]:
http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html#tag_09_03_05
