### PR TITLE
Discuss shebang #! in novice Bash lesson?

### DIFF
--- a/bash/novice/guide.md
+++ b/bash/novice/guide.md
@@ -107,8 +107,14 @@ Teaching Notes
     including file permissions, job control, and SSH.
     If learners already understand the basic material,
     this can be covered instead using the online lessons as guidelines.
+    These limitations also have follow-on consequences:
+
+    * Without file permissions, it's hard to discuss [script
+      shebangs][shebang] (e.g. `#!/bin/sh`).
 
 *   Installing Bash and a reasonable set of Unix commands on Windows
     always involves some fiddling and frustration.
     Please see the latest set of installation guidelines for advice,
     and try it out yourself *before* teaching a class.
+
+[shebang]: http://en.wikipedia.org/wiki/Shebang_%28Unix%29


### PR DESCRIPTION
The novice lessons currently don't discuss the [shebang](http://en.wikipedia.org/wiki/Shebang_%28Unix%29).  I don't have solid numbers, but I have seen very few scripts without these leading comments, which are useful for typing reduction, and also to avoid accidentally running a Bash script from a POSIX shell (or other mix-ups).  I think the mental overhead of this additional syntax is outweighed by the benefit of not having to remember which language the script is written in when you call it later.

This is more of a Unix-ism than a shell-specific feature, but the Bash scripting lesson seems like a good place to address it.
