### PR TITLE
swc-windows-installer.py: Quote $PATH export to account for spaces.

### DIFF
--- a/setup/swc-windows-installer.py
+++ b/setup/swc-windows-installer.py
@@ -83,7 +83,7 @@ def update_bash_profile(extra_paths=()):
     lines = [
         '',
         '# Add paths for Software-Carpentry-installed scripts and executables',
-        'export PATH=$PATH:{}'.format(':'.join(
+        'export PATH=\"$PATH:{}\"'.format(':'.join(
             make_posix_path(path) for path in extra_paths),),
         '',
         '# Make nano the default editor',


### PR DESCRIPTION
Many people have spaces in their Windows user names, leading to trouble with
an unquoted $PATH export.  This file now quotes the $PATH addition
accordingly.

The same change as #267 and #268, but via my windows-installer repo
for easier sharing.
