### PR TITLE
Fix 404 for license

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,6 +4,6 @@
   <a class="label swc-blue-bg" href="{{site.twitter_url}}">Twitter</a>
   <a class="label swc-blue-bg" href="{{site.github_url}}">GitHub</a>
   <a class="label swc-blue-bg" href="{{site.rss_url}}">RSS</a>
-  <a class="label swc-blue-bg" href="{{page.root}}/license.html">License</a>
+  <a class="label swc-blue-bg" href="{{page.root}}/LICENSE.html">License</a>
   <a class="bugreport label swc-blue-bg" href="mailto:{{site.contact}}?subject=bug%20in%20{{page.path}}">Bug Report</a>
 </div>


### PR DESCRIPTION
## Summary

When try to read the license of the lessons from the home page of bootcamps we got 404 error.
## How to reproduce
1. Go to the home page of any [future bootcamp](http://software-carpentry.org/bootcamps/) (e.g. [Stanford University](http://arokem.github.io/2014-01-27-Stanford/), [University of Miami](http://jennybc.github.io/2014-01-27-miami/)).
2. Go to the end of the page.
3. Click on "License" icon.

**Warning**: some http server are case-insensitive but look like github.io isn't.
## Reason

The file is `LICENSE.html` and not `license.html`.
## Solution

Fix the file name.
