### PR TITLE
Opt-out map in home page of bootcamps

### DIFF
--- a/_includes/bootcamps/where.html
+++ b/_includes/bootcamps/where.html
@@ -1,0 +1,8 @@
+{% if page.latlng %}
+<p>
+  <strong>Where:</strong>
+  {{ page.address }}. Get directions with <a
+    href="http://www.openstreetmap.org/?mlat={{ page.latlng | replace:',','&mlon=' }}&zoom=16">OpenStreetMap</a> or <a
+    href="http://maps.google.com/maps?q={{ page.latlng }}">Google Maps</a>.
+</p>
+{% endif %}

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@ contact: random@software-carpentry.org
 {% include bootcamps/instructors.html %}
 {% include bootcamps/what.html %}
 {% include bootcamps/who.html %}
+{% include bootcamps/where.html %}
 {% include bootcamps/requirements.html %}
 {% include bootcamps/python.html %}
 {% include bootcamps/contact.html %}


### PR DESCRIPTION
Someone suggest to me that the home page have one map showing the location. This PR adds Google Maps in the home page (something is broken with [openlayers](http://www.openlayers.org/dev/examples/markers.html) when I try using it to add Open Street Maps).

**Note**: The maps isn't visible yet due CSS configuration, if you disable `position: relative;` in `#map-canvas` you will see the map at the top of the page. **I need help to solve this CSS issue**.
