### PR TITLE
CONTRIBUTING.md: Replace AstroPy links with GitHub's Flow guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,15 +66,13 @@ admin@software-carpentry.org.
 More Information
 ----------------
 
-Software Carpentry uses a development workflow similar to that of
-[AstroPy][] and many other open source projects. The AstroPy docs have
-excellent sections on:
+Software Carpentry uses a development workflow similar to that of many
+other open source projects.  For a graphical introduction to feature
+branches as we use them, see GitHub's [workflow
+guide][github-workflow].  For more information about getting started
+with Git, see [our Git lesson][git-lesson].
 
-* [Getting started with git][astropy-git]
-* [Developer workflow][astropy-workflow]
-
-[AstroPy]: http://astropy.org
-[astropy-git]: http://astropy.readthedocs.org/en/latest/development/workflow/index.html#getting-started-with-git
-[astropy-workflow]: http://astropy.readthedocs.org/en/latest/development/workflow/development_workflow.html
+[github-workflow]: http://guides.github.com/overviews/flow/
+[git-lesson]: ./git/novice/index.md
 [creators]: http://software-carpentry.org/badges/creator.html
 [licenses]: http://software-carpentry.org/license.html


### PR DESCRIPTION
GitHub just deployed some guides [1](https://github.com/blog/1769-announcing-guides), so we can reverence them (with their
pretty graphics and accessible UI) instead of the AstroPy docs.

GitHub's guide is pretty, but it doesn't go into lots of technical detail
(e.g. how do I make a commit or open a pull request?), so we still need a link
to a Git tutorial.  I've replaced the old AstroPy link with one to our own
novice lesson, since we might as well eat our own dog food.
