### PR TITLE
Mailmap from boot camps repo

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,7 +1,18 @@
+Aron Ahmadia <aron@ahmadia.net> <aron@ahmadia.net>
+Cath Ly <briarrose5187@gmail.com> <briarrose5187@gmail.com>
+Christina Koch <christinkconnect@gmail.com> <christinkconnect@gmail.com>
 Joshua Ryan Smith <joshua.r.smith@gmail.com> <joshua.r.smith@gmail.com>
 Katy Huff <katyhuff@gmail.com> <katyhuff@gmail.com>
+Lex Nederbragt <lex.nederbragt@bio.uio.no> <lex.nederbragt@bio.uio.no>
 Lynne Williams <williams.lynne99@gmail.com> <alw@Lynne-Williamss-MacBook.local>
 Lynne Williams <williams.lynne99@gmail.com> <williams.lynne99@gmail.com>
+Matt Billard <matt@photon.man> <matt@photon.man>
 Matt Davis <jiffyclub@gmail.com> <jiffyclub.programatic@gmail.com>
 Matt Davis <jiffyclub@gmail.com> <jiffyclub@gmail.com>
+Molly Gibson <mollykrisann@gmail.com> <mgibson@Molly-Gibsons-MacBook-Pro.local>
+Molly Gibson <mollykrisann@gmail.com> <mollykrisann@gmail.com>
+Scott Chamberlain <myrmecocystus@gmail.com> <myrmecocystus@gmail.com>
 Sri Hari Krishna Narayanan <sriharikrishna@gmail.com> <snarayan@mcswl169.mcs.anl.gov>
+Steven Haddock <haddock@mbari.org> <haddock@mbari.org>
+Trent Hauck <trent@trenthauck.com> <thauck@alightanalytics.com>
+Yuxi Luo <iamaplayer@gmail.com> <iamaplayer@gmail.com>


### PR DESCRIPTION
Requested by @gvwilson in #287.

The previous two commits came from swcarpentry/boot-camps#9 and swcarpentry/boot-camps#24.  This adds entries for other authors, as far as I could determine from searching the GitHub and the wider net.  Before this gets merged, it would be nice to get confirmations from the folks I've mapped (@cavestruz, @ChristinaK, @lexnederbragt, @mattphotonman, @mollygibson, @sckott, @tshauck, and @HaveF) that this is the name they want us to use.  I couldn't find a GitHub account for Steve Haddock, but I'm pretty sure I [have that mapping right](http://www.mbari.org/staff/haddock/) ;).
