### PR TITLE
Fix link to contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ how you can build a website for your bootcamp using this repo as a starting poin
 what lessons we have,
 and where they're located.
 To contribute corrections or additions to this repository, see the
-[contribution guidelines][CONTRIBUTING.html].
+[contribution guidelines](CONTRIBUTING.md).
 
 **Note:**
 If you are teaching Git in your bootcamp,


### PR DESCRIPTION
README link to CONTRIBUTING was broken, both because link syntax was incorrect and because these pages don't render as html and are only viewed in Markdown (so link should go to CONTRIBUTING.md)
