### PR TITLE
[v5] Fix anchor name conversion in book glossary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ index.html setup.md : _includes/setup.html
 # Patch targets and links in the glossary for inclusion in the book.
 tmp/gloss.md : gloss.md
 	@mkdir -p $$(dirname $@)
-	sed -e 's!](#!](#g:!g' -e 's!<a name="!<a name="#g:!g' $< > $@
+	sed -e 's!](#!](#g:!g' -e 's!<a name="!<a name="g:!g' $< > $@
 
 # Patch image paths in the sections.
 tmp/novice/shell/%.md : novice/shell/%.md


### PR DESCRIPTION
Corrects line in Makefile to get working links to glossary items in `book.html` (was inserting `#` before anchor name). Fixes #327.
