### PR TITLE
Bringing in up-to-date instructions for installing Firefox SQLite Manager plugin

### DIFF
--- a/_includes/setup.html
+++ b/_includes/setup.html
@@ -307,7 +307,28 @@
       Instead of using <code>sqlite3</code> from the command line,
       you may use <a href="https://addons.mozilla.org/en-US/firefox/addon/sqlite-manager/">this plugin</a>
       for Firefox instead.
+      To install it:
     </p>
+    <ul>
+      <li>
+	Start Firefox.
+      </li>
+      <li>
+	Go to the <a href="https://addons.mozilla.org/en-US/firefox/addon/sqlite-manager/">plugin homepage</a>.
+      </li>
+      <li>
+	Click the "Add Now" button.
+      </li>
+      <li>
+	Click "Install Now" on the dialog that appears after the download completes.
+      </li>
+      <li>
+	Restart Firefox when prompted.
+      </li>
+      <li>
+	Select "SQLite Manager" from the "Tools" menu.
+      </li>
+    </ul>
   </div>
   <div class="span6">
     <h4>Virtual Machine</h4>


### PR DESCRIPTION
These instructions were dropped when inlining the setup instructions, and were out of date anyway.
