### PR TITLE
Adding link to the VM image and setup instructions.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,4 +11,5 @@ rss_url         : "http://software-carpentry.org/feed.xml"
 swc_prefix      : "http://software-carpentry.org"
 twitter_name    : "@swcarpentry"
 twitter_url     : "https://twitter.com/swcarpentry"
+vm_url          : "https://docs.google.com/uc?id=0B4Kr6DYkzkQtd05FekRId05DLXM&amp;export=download"
 exclude         : [branding, data, tmp, swc.tpl]

--- a/_includes/setup.html
+++ b/_includes/setup.html
@@ -315,8 +315,22 @@
       Some instructors prefer to have learners use a virtual machine (VM)
       rather than install software on their own computers.
       If your instructors have chosen to do this,
-      please follow the instructions they have given you
-      to install and configure the VM.
+      please:
     </p>
+    <ol>
+      <li>
+	Install <a href="https://www.virtualbox.org/">VirtualBox</a>.
+      </li>
+      <li>
+	Download our <a href="{{site.vm_url}}">VM image</a>.
+	<strong>Warning:</strong>
+	this file is 1.7 GByte,
+	so please download it <em>before</em> coming to your bootcamp.
+      </li>
+      <li>
+	Load the VM into VirtualBox by selecting "Import Appliance"
+	and loading the <code>.ova</code> file.
+      </li>
+    </ol>
   </div>
 </div>


### PR DESCRIPTION
This adds a new configuration variable `vm_url` that points to wherever the VM image is located, and links to it from `_includes/setup.html`.  This setup allows per-bootcamp customization of the VM if desired.
