### PR TITLE
Add 'Software Carpentry' to title by default...

### DIFF
--- a/_layouts/bootcamp.html
+++ b/_layouts/bootcamp.html
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Software Carpentry &mdash; {{ page.venue }}</title>
+    <title>Software Carpentry: {{ page.venue }}</title>
     {% include header.html %}
     <meta name="venue" content="{{page.venue}}" />
     <meta name="date" content="{{page.humandate}}" />


### PR DESCRIPTION
...instead of *just the venue name, which to me looks odd.
