### PR TITLE
Add navigation links in lessons (v5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,8 @@ INDEX = $(SITE)/index.html
 # having the output index.html file depend on all the page source
 # Markdown files triggers the desired build once and only once.
 $(INDEX) : ./index.html $(ALL_SRC) $(CONFIG) $(EXTRAS)
-	 jekyll -t build -d $(SITE)
+	bin/set_nav_links.py ${ALL_SRC}
+	jekyll -t build -d $(SITE)
 
 #----------------------------------------------------------------------
 # Create all-in-one book version of notes.

--- a/_layouts/lesson.html
+++ b/_layouts/lesson.html
@@ -15,6 +15,21 @@
 
       <div class="row-fluid">
         <div class="span10 offset1">
+          {% if page.prev or page.next %}
+          <!-- start nav -->
+          <nav>
+            <ul class="pager">
+              {% if page.prev %}
+              <li class="previous"><a href="{{ page.prev | replace: ".md", ".html" }}">Previous</a></li>
+              {% endif %}
+              <li class="uplink"><a href="index.html">Index</a></li>
+              {% if page.next %}
+              <li class="next"><a href="{{ page.next | replace: ".md", ".html" }}">Next</a></li>
+              {% endif %}
+            </ul>
+          </nav>
+          <!-- end nav -->
+          {% endif %}
 	  <!-- start content -->
           {% if page.title %}
           <h1>{{page.title}}</h1>

--- a/bin/set_nav_links.py
+++ b/bin/set_nav_links.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+"""
+This set the navigation links for lessons.
+"""
+
+import os
+import os.path
+import re
+import warnings
+
+def write_nav(afile_, alines, aprev, anext):
+    """Write updated navigation into file"""
+    end_of_yaml = False
+    for line in alines:
+        # Locate YAML
+        if '---\n' == line:
+            if end_of_yaml:
+                if aprev:
+                    afile_.write("prev: {}\n".format(aprev))
+                if anext:
+                    afile_.write("next: {}\n".format(anext))
+                end_of_yaml = False
+            else:
+                end_of_yaml = True
+
+        # Ignoring previous navigation
+        if "prev:" in line or "next:" in line:
+            pass
+        else:
+            afile_.write(line)
+
+def get_nav(afile_name):
+    """Discovery the previous and next lesson."""
+    prev_lesson = None
+    next_lesson = None
+
+    file_name_head, file_name_tail = os.path.split(afile_name)
+    if file_name_head != '':
+        list_files = os.listdir(file_name_head)
+
+        pattern = re.compile('^(?P<number>\d\d)-.*\.md')
+        this_lesson = pattern.match(file_name_tail)
+        if this_lesson:
+            this_lesson_number = int(this_lesson.group("number"))
+
+            for file_ in list_files:
+                other_lesson = pattern.match(file_)
+                if other_lesson:
+                    other_lesson_number = int(other_lesson.group("number"))
+                    if other_lesson_number == this_lesson_number - 1:
+                        prev_lesson = file_
+                    if other_lesson_number == this_lesson_number + 1:
+                        next_lesson = file_
+
+    return prev_lesson, next_lesson
+
+def set_nav(afile_name):
+    """Set the navigation links into file."""
+    if os.path.isfile(afile_name):
+        prev_lesson, next_lesson = get_nav(afile_name)
+
+        with open(afile_name, 'r') as file_:
+            lines = file_.readlines()
+
+        with open(afile_name, 'w') as file_:
+            write_nav(file_, lines, prev_lesson, next_lesson)
+    else:
+        warnings.warn("{} isn't a regular file.".format(afile_name), 
+                UserWarning)
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+            description="Script to set navigation links")
+
+    parser.add_argument("file_name", nargs="+",
+            help="The files to set the navigation links")
+
+    parsed_args = parser.parse_args()
+
+    for file_name in parsed_args.file_name:
+        try:
+            set_nav(file_name)
+        except FileNotFoundError as err:
+            print(err)

--- a/intermediate/doit/01-doit_basics.md
+++ b/intermediate/doit/01-doit_basics.md
@@ -1,6 +1,7 @@
 ---
 layout: lesson
 root: ../..
+next: 02-sub_tasks.md
 ---
 
 ## Automating Tasks With "doit"

--- a/intermediate/doit/02-sub_tasks.md
+++ b/intermediate/doit/02-sub_tasks.md
@@ -1,6 +1,8 @@
 ---
 layout: lesson
 root: ../..
+prev: 01-doit_basics.md
+next: 03-uptodate.md
 ---
 
 ## Using sub-tasks to define a group of similar tasks

--- a/intermediate/doit/03-uptodate.md
+++ b/intermediate/doit/03-uptodate.md
@@ -1,6 +1,7 @@
 ---
 layout: lesson
 root: ../..
+prev: 02-sub_tasks.md
 ---
 
 ## Determining if doit needs to run a task

--- a/intermediate/python/01-intro-python.md
+++ b/intermediate/python/01-intro-python.md
@@ -1,6 +1,7 @@
 ---
 layout: lesson
 root: ../..
+next: 02-modularization-documentation.md
 ---
 
 # Introduction

--- a/intermediate/python/02-modularization-documentation.md
+++ b/intermediate/python/02-modularization-documentation.md
@@ -1,6 +1,8 @@
 ---
 layout: lesson
 root: ../..
+prev: 01-intro-python.md
+next: 03-qa.md
 ---
 
 # Modularization and Documentation

--- a/intermediate/python/03-qa.md
+++ b/intermediate/python/03-qa.md
@@ -1,6 +1,8 @@
 ---
 layout: lesson
 root: ../..
+prev: 02-modularization-documentation.md
+next: 04-multiprocessing.md
 ---
 
 # Getting the Right Answer

--- a/intermediate/python/04-multiprocessing.md
+++ b/intermediate/python/04-multiprocessing.md
@@ -1,6 +1,7 @@
 ---
 layout: lesson
 root: ../..
+prev: 03-qa.md
 ---
 
 # Parallel programming with Python's multiprocessing library

--- a/novice/extras/01-branching.md
+++ b/novice/extras/01-branching.md
@@ -2,6 +2,7 @@
 layout: lesson
 root: ../..
 title: Branching in Git
+next: 02-review.md
 ---
 Here's where we are right now:
 

--- a/novice/extras/02-review.md
+++ b/novice/extras/02-review.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Code Review
+prev: 01-branching.md
+next: 03-man.md
 ---
 The model shown in the [main lesson](../git/02-collab.html)
 in which everyone pushes and pulls from a single repository,

--- a/novice/extras/03-man.md
+++ b/novice/extras/03-man.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Manual Pages
+prev: 02-review.md
+next: 04-permissions.md
 ---
 We can get help for any Unix command with the `man`
 (short for manual) command.

--- a/novice/extras/04-permissions.md
+++ b/novice/extras/04-permissions.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Permissions
+prev: 03-man.md
+next: 05-shellvar.md
 ---
 Unix controls who can read, modify, and run files using *permissions*.
 We'll discuss how Windows handles permissions at the end of the section:

--- a/novice/extras/05-shellvar.md
+++ b/novice/extras/05-shellvar.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Shell Variables
+prev: 04-permissions.md
+next: 06-ssh.md
 ---
 The shell is just a program, and like other programs, it has variables.
 Those variables control its execution,

--- a/novice/extras/06-ssh.md
+++ b/novice/extras/06-ssh.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Working Remotely
+prev: 05-shellvar.md
+next: 07-exceptions.md
 ---
 Let's take a closer look at what happens when we use the shell
 on a desktop or laptop computer.

--- a/novice/extras/07-exceptions.md
+++ b/novice/extras/07-exceptions.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Exceptions
+prev: 06-ssh.md
+next: 08-numbers.md
 ---
 Assertions help us catch errors in our code,
 but things can go wrong for other reasons,

--- a/novice/extras/08-numbers.md
+++ b/novice/extras/08-numbers.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Numbers
+prev: 07-exceptions.md
+next: 09-why.md
 ---
 Let's start by looking at how numbers are stored.
 If we only have the two digits 0 and 1,

--- a/novice/extras/09-why.md
+++ b/novice/extras/09-why.md
@@ -2,6 +2,7 @@
 layout: lesson
 root: ../..
 title: Why I Teach
+prev: 08-numbers.md
 ---
 This is my daughter Madeline:
 

--- a/novice/git/00-intro.md
+++ b/novice/git/00-intro.md
@@ -2,6 +2,7 @@
 layout: lesson
 root: ../..
 title: Introducing Version Control
+next: 01-backup.md
 ---
 Wolfman and Dracula have been hired by Universal Missions
 (a space services spinoff from Euphoric State University)

--- a/novice/git/01-backup.md
+++ b/novice/git/01-backup.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: A Better Kind of Backup
+prev: 00-intro.md
+next: 02-collab.md
 ---
 <div class="objectives" markdown="1">
 

--- a/novice/git/02-collab.md
+++ b/novice/git/02-collab.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Collaborating
+prev: 01-backup.md
+next: 03-conflict.md
 ---
 <div class="objectives" markdown="1">
 

--- a/novice/git/03-conflict.md
+++ b/novice/git/03-conflict.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Conflicts
+prev: 02-collab.md
+next: 04-open.md
 ---
 <div class="objectives" markdown="1">
 

--- a/novice/git/04-open.md
+++ b/novice/git/04-open.md
@@ -2,6 +2,7 @@
 layout: lesson
 root: ../..
 title: Open Science
+prev: 03-conflict.md
 ---
 <div class="objectives" markdown="1">
 

--- a/novice/python/01-numpy.md
+++ b/novice/python/01-numpy.md
@@ -1,6 +1,7 @@
 ---
 layout: lesson
 root: ../..
+next: 02-func.md
 ---
 
 ## Analyzing Patient Data

--- a/novice/python/02-func.md
+++ b/novice/python/02-func.md
@@ -1,6 +1,8 @@
 ---
 layout: lesson
 root: ../..
+prev: 01-numpy.md
+next: 03-loop.md
 ---
 
 ## Creating Functions

--- a/novice/python/03-loop.md
+++ b/novice/python/03-loop.md
@@ -1,6 +1,8 @@
 ---
 layout: lesson
 root: ../..
+prev: 02-func.md
+next: 04-cond.md
 ---
 
 ## Analyzing Multiple Data Sets

--- a/novice/python/04-cond.md
+++ b/novice/python/04-cond.md
@@ -1,6 +1,8 @@
 ---
 layout: lesson
 root: ../..
+prev: 03-loop.md
+next: 05-defensive.md
 ---
 
 ## Making Choices

--- a/novice/python/05-defensive.md
+++ b/novice/python/05-defensive.md
@@ -1,6 +1,8 @@
 ---
 layout: lesson
 root: ../..
+prev: 04-cond.md
+next: 06-cmdline.md
 ---
 
 ## Defensive Programming

--- a/novice/python/06-cmdline.md
+++ b/novice/python/06-cmdline.md
@@ -1,6 +1,7 @@
 ---
 layout: lesson
 root: ../..
+prev: 05-defensive.md
 ---
 
 ## Command-Line Programs

--- a/novice/ref/01-shell.md
+++ b/novice/ref/01-shell.md
@@ -2,6 +2,7 @@
 layout: lesson
 root: ../..
 title: Shell Reference
+next: 02-git.md
 ---
 
 #### Basic Commands

--- a/novice/ref/02-git.md
+++ b/novice/ref/02-git.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Git Reference
+prev: 01-shell.md
+next: 03-python.md
 ---
 Set global configuration (only needs to be done once per machine):
 

--- a/novice/ref/03-python.md
+++ b/novice/ref/03-python.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Python Reference
+prev: 02-git.md
+next: 04-sql.md
 ---
 
 #### Basic Operations

--- a/novice/ref/04-sql.md
+++ b/novice/ref/04-sql.md
@@ -2,6 +2,7 @@
 layout: lesson
 root: ../..
 title: SQL Reference
+prev: 03-python.md
 ---
 
 #### Basic Queries

--- a/novice/shell/00-intro.md
+++ b/novice/shell/00-intro.md
@@ -2,6 +2,7 @@
 layout: lesson
 root: ../..
 title: Introducing the Shell
+next: 01-filedir.md
 ---
 <div class="objectives" markdown="1">
 

--- a/novice/shell/01-filedir.md
+++ b/novice/shell/01-filedir.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Files and Directories
+prev: 00-intro.md
+next: 02-create.md
 ---
 <div class="objectives" markdown="1">
 

--- a/novice/shell/02-create.md
+++ b/novice/shell/02-create.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Creating Things
+prev: 01-filedir.md
+next: 03-pipefilter.md
 ---
 <div class="objectives" markdown="1">
 

--- a/novice/shell/03-pipefilter.md
+++ b/novice/shell/03-pipefilter.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Pipes and Filters
+prev: 02-create.md
+next: 04-loop.md
 ---
 <div class="objectives" markdown="1">
 

--- a/novice/shell/04-loop.md
+++ b/novice/shell/04-loop.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Loops
+prev: 03-pipefilter.md
+next: 05-script.md
 ---
 <div class="objectives" markdown="1">
 

--- a/novice/shell/05-script.md
+++ b/novice/shell/05-script.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Shell Scripts
+prev: 04-loop.md
+next: 06-find.md
 ---
 <div class="objectives" markdown="1">
 

--- a/novice/shell/06-find.md
+++ b/novice/shell/06-find.md
@@ -2,6 +2,7 @@
 layout: lesson
 root: ../..
 title: Finding Things
+prev: 05-script.md
 ---
 <div class="objectives" markdown="1">
 

--- a/novice/sql/01-select.md
+++ b/novice/sql/01-select.md
@@ -1,6 +1,7 @@
 ---
 layout: lesson
 root: ../..
+next: 02-sort-dup.md
 ---
 
 ## Selecting Data

--- a/novice/sql/02-sort-dup.md
+++ b/novice/sql/02-sort-dup.md
@@ -1,6 +1,8 @@
 ---
 layout: lesson
 root: ../..
+prev: 01-select.md
+next: 03-filter.md
 ---
 
 ## Sorting and Removing Duplicates

--- a/novice/sql/03-filter.md
+++ b/novice/sql/03-filter.md
@@ -1,6 +1,8 @@
 ---
 layout: lesson
 root: ../..
+prev: 02-sort-dup.md
+next: 04-calc.md
 ---
 
 ## Filtering

--- a/novice/sql/04-calc.md
+++ b/novice/sql/04-calc.md
@@ -1,6 +1,8 @@
 ---
 layout: lesson
 root: ../..
+prev: 03-filter.md
+next: 05-null.md
 ---
 
 ## Calculating New Values

--- a/novice/sql/05-null.md
+++ b/novice/sql/05-null.md
@@ -1,6 +1,8 @@
 ---
 layout: lesson
 root: ../..
+prev: 04-calc.md
+next: 06-agg.md
 ---
 
 ## Missing Data

--- a/novice/sql/06-agg.md
+++ b/novice/sql/06-agg.md
@@ -1,6 +1,8 @@
 ---
 layout: lesson
 root: ../..
+prev: 05-null.md
+next: 07-join.md
 ---
 
 ## Aggregation

--- a/novice/sql/07-join.md
+++ b/novice/sql/07-join.md
@@ -1,6 +1,8 @@
 ---
 layout: lesson
 root: ../..
+prev: 06-agg.md
+next: 08-create.md
 ---
 
 ## Combining Data

--- a/novice/sql/08-create.md
+++ b/novice/sql/08-create.md
@@ -1,6 +1,8 @@
 ---
 layout: lesson
 root: ../..
+prev: 07-join.md
+next: 09-prog.md
 ---
 
 ## Creating and Modifying Data

--- a/novice/sql/09-prog.md
+++ b/novice/sql/09-prog.md
@@ -1,6 +1,7 @@
 ---
 layout: lesson
 root: ../..
+prev: 08-create.md
 ---
 
 ## Programming with Databases

--- a/novice/teaching/01-general.md
+++ b/novice/teaching/01-general.md
@@ -3,6 +3,7 @@ layout: lesson
 root: ../..
 title: General Advice
 level: novice
+next: 02-shell.md
 ---
 This is a placeholder for general notes about teaching.
 For up-to-date information about software installation and configuration problems,

--- a/novice/teaching/02-shell.md
+++ b/novice/teaching/02-shell.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: The Unix Shell
+prev: 01-general.md
+next: 03-git.md
 ---
 Many people have questioned whether we should still teach the shell.
 After all,

--- a/novice/teaching/03-git.md
+++ b/novice/teaching/03-git.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Version Control with Git
+prev: 02-shell.md
+next: 04-python.md
 ---
 Version control might be the most important topic we teach,
 but Git is definitely the most complicated tool.

--- a/novice/teaching/04-python.md
+++ b/novice/teaching/04-python.md
@@ -2,6 +2,8 @@
 layout: lesson
 root: ../..
 title: Programming with Python
+prev: 03-git.md
+next: 05-sql.md
 ---
 This lesson is written as an introduction to Python,
 but its real purpose is to introduce the single most important idea in programming:

--- a/novice/teaching/05-sql.md
+++ b/novice/teaching/05-sql.md
@@ -2,6 +2,7 @@
 layout: lesson
 root: ../..
 title: Using Databases and SQL
+prev: 04-python.md
 ---
 Relational databases are not as widely used in science as in business,
 but they are still a common way to store large data sets with complex structure.


### PR DESCRIPTION
This is a **work in progress** for #214. **Don't merge it yet.**
## Abstract

Right now our lessons don't have a navigation bar with links to previous and next lesson as show in the screenshot below.

![swc-no-nav](https://f.cloud.github.com/assets/1506457/2429561/032c466e-ac8a-11e3-8a91-9e80f0db9d2b.jpg)

This PR add this useful navigation bar as show in the screenshot below.

![swc-nav](https://f.cloud.github.com/assets/1506457/2429567/2bd80f12-ac8a-11e3-987e-4d39dbd2e21f.jpg)
## Technical details

The navigation bar can be build using **only** Jekyll's template (but I fail to do it, you can check what I do in r-gaia-cs/bc@715c5bd) or adding the information needed in YAML header (what this PR does).

Add the information needed to the navigation bar in YAML header have the disadvantage that it will need to be update at some point (this isn't a big problem because `make` can do it) and for lessons wrote using IPython Notebook it need to be add after the `.ipynb` is converted to `.md`.
## TODO
- Improve the navigation layout using CSS
  
  I invite all CSS experts to send a PR to fix this.
- Improve the `Makefile` to handle IPython Notebook lessons properly
  
  @gvwilson Can you take a look on it?
