### PR TITLE
Add CSS media query to improve logo position

### DIFF
--- a/css/swc.css
+++ b/css/swc.css
@@ -84,6 +84,12 @@ div.banner a img {
     padding: 20px 25px;
 }
 
+@media (max-width: 700px) {
+    div.banner a img {
+        padding: 20px 0px;
+    }
+}
+
 /* Explanatory call-out boxes. */
 div.box {
     background-color: mistyrose;


### PR DESCRIPTION
When using mobile devices the SWC logo overflow the box as showed below:

![screen shot 2014-03-02 at 13 35 17](https://f.cloud.github.com/assets/1506457/2438660/7a8a81b0-adf4-11e3-9ad7-5b51a3d3a5f4.png)

This PR add a small CSS media query to avoid this problem (as showed below) using the same query used in for others elements.

![screen shot 2014-03-02 at 13 44 03](https://f.cloud.github.com/assets/1506457/2438697/debeed60-adf4-11e3-9d62-f572525145c2.png)
