### PR TITLE
Fix links to glossary

### DIFF
--- a/intermediate/git/01-conversational-git.md
+++ b/intermediate/git/01-conversational-git.md
@@ -43,7 +43,7 @@ After this lesson, students should be able to:
 ## Copying Repositories (git clone)
 
 The first concept we introduce
-is the [repository](../gloss.html#repository).
+is the [repository](../../gloss.html#repository).
 The repository contains a directory of files and folders
 and their revisions going back to its creation.
 

--- a/novice/extras/01-branching.md
+++ b/novice/extras/01-branching.md
@@ -51,7 +51,7 @@ $ git branch moons
 </div>
 
 It appears to do nothing,
-but behind the scenes it has created a new [branch](../gloss.html#branch) called `moons`:
+but behind the scenes it has created a new [branch](../../gloss.html#branch) called `moons`:
 
 <div class="in" markdown="1">
 ~~~
@@ -278,7 +278,7 @@ Our repository is now in this state:
 `master` and `moons` have both moved on from their original common state,
 but in different ways.
 They could continue independent existence indefinitely,
-but at some point we'll probably want to [merge](../gloss.html#merge) our changes.
+but at some point we'll probably want to [merge](../../gloss.html#merge) our changes.
 Let's do that now:
 
 <div class="in" markdown="1">

--- a/novice/extras/02-review.md
+++ b/novice/extras/02-review.md
@@ -7,7 +7,7 @@ The model shown in the [main lesson](../git/02-collab.html)
 in which everyone pushes and pulls from a single repository,
 is perfectly usable,
 but there's one thing it *doesn't* let us do:
-[code review](../gloss.html#code-review).
+[code review](../../gloss.html#code-review).
 Suppose Dracula wants to be able to look at Wolfman's changes before merging them into the master copy on GitHub,
 just as he would review Wolfman's paper before publishing it
 (or perhaps even before submitting it for publication).
@@ -21,7 +21,7 @@ most programmers take a slightly more roundabout route to merging.
 When the project starts,
 Dracula creates a repository on GitHub
 in exactly the same way as [we created the `planets` repository](../git/02-collab.html)
-and then [clones](../gloss.html#repository-clone) it to his desktop:
+and then [clones](../../gloss.html#repository-clone) it to his desktop:
 
 <div class="in" markdown="1">
 ~~~
@@ -56,7 +56,7 @@ Dracula can now push and pull changes just as before.
 
 Wolfman doesn't clone Dracula's GitHub repository directly.
 Instead,
-he [forks](../gloss.html#repository-fork) it,
+he [forks](../../gloss.html#repository-fork) it,
 i.e., clones it on GitHub. He does this using the GitHub web interface:
 
 <img src="img/git-fork-ui.png" alt="The Fork Button" />
@@ -75,7 +75,7 @@ then uses `git push` to copy those changes to GitHub:
 
 <img src="img/git-forking-02.svg" alt="After Pushing to Fork" />
 
-He then creates a [pull request](../gloss.html#pull-request),
+He then creates a [pull request](../../gloss.html#pull-request),
 which notifies Dracula that Wolfman wants to merge some changes into Dracula's repository:
 
 <img src="img/git-forking-03.svg" alt="After Creating Pull Request" />

--- a/novice/extras/04-permissions.md
+++ b/novice/extras/04-permissions.md
@@ -9,9 +9,9 @@ the concepts are similar,
 but the rules are different.
 
 Let's start with Nelle.
-She has a unique [user name](../gloss.html#user-name),
+She has a unique [user name](../../gloss.html#user-name),
 `nnemo`,
-and a [user ID](../gloss.html#user-id),
+and a [user ID](../../gloss.html#user-id),
 1404.
 
 > #### Why Integer IDs?
@@ -35,9 +35,9 @@ and a [user ID](../gloss.html#user-id),
 > in the same way that someone working in a lab might talk about Experiment 28
 > instead of "the chronotypical alpha-response trials on anacondas".
 
-Users can belong to any number of [groups](../gloss.html#user-group),
-each of which has a unique [group name](../gloss.html#user-group-name)
-and numeric [group ID](../gloss.html#user-group-id).
+Users can belong to any number of [groups](../../gloss.html#user-group),
+each of which has a unique [group name](../../gloss.html#user-group-name)
+and numeric [group ID](../../gloss.html#user-group-id).
 The list of who's in what group is usually stored in the file `/etc/group`.
 (If you're in front of a Unix machine right now,
 try running `cat /etc/group` to look at that file.)
@@ -302,7 +302,7 @@ without opening up everything else.
 
 Those are the basics of permissions on Unix.
 As we said at the outset, though, things work differently on Windows.
-There, permissions are defined by [access control lists](../gloss.html#access-control-list),
+There, permissions are defined by [access control lists](../../gloss.html#access-control-list),
 or ACLs.
 An ACL is a list of pairs, each of which combines a "who" with a "what".
 For example,

--- a/novice/extras/05-shellvar.md
+++ b/novice/extras/05-shellvar.md
@@ -54,7 +54,7 @@ it's the program's responsibility to split the variable's string value into piec
 #### The `PATH` Variable
 
 Let's have a closer look at that `PATH` variable.
-Its value defines the shell's [search path](../gloss.html#search-path),
+Its value defines the shell's [search path](../../gloss.html#search-path),
 i.e., the list of directories that the shell looks in for runnable programs
 when you type in a program name without specifying what directory it is in.
 

--- a/novice/extras/06-ssh.md
+++ b/novice/extras/06-ssh.md
@@ -23,7 +23,7 @@ What if we want to run some commands on another machine,
 such as the server in the basement that manages our database of experimental results?
 To do this,
 we have to first log in to that machine.
-We call this a [remote login](../gloss.html#remote-login),
+We call this a [remote login](../../gloss.html#remote-login),
 and the other computer a remote computer.
 Once we do this,
 everything we type is passed to a shell running on the remote computer.
@@ -31,7 +31,7 @@ That shell runs those commands on our behalf,
 just as a local shell would,
 then sends back output for our computer to display.
 
-The tool we use to log in remotely is the [secure shell)(../gloss.html#secure-shell),
+The tool we use to log in remotely is the [secure shell)(../../gloss.html#secure-shell),
 or SSH.
 In particular, the command `ssh username@computer`
 runs SSH and connects to the remote computer we have specified.
@@ -200,7 +200,7 @@ and sends the output back to our local shell for display.
 > Typing our password over and over again is annoying,
 > especially if the commands we want to run remotely are in a loop.
 > To remove the need to do this,
-> we can create an [authentication key](../../gloss.html#authentication-key)
+> we can create an [authentication key](../../../gloss.html#authentication-key)
 > to tell the remote machine
 > that it should always trust us.
 > We discuss authentication keys in our intermediate lessons.

--- a/novice/extras/07-exceptions.md
+++ b/novice/extras/07-exceptions.md
@@ -7,7 +7,7 @@ Assertions help us catch errors in our code,
 but things can go wrong for other reasons,
 like missing or badly-formatted files.
 Most modern programming languages allow programmers to use
-[exceptions](../gloss.html#exception) to separate
+[exceptions](../../gloss.html#exception) to separate
 what the program should do if everything goes right
 from what it should do if something goes wrong.
 Doing this makes both cases easier to read and understand.

--- a/novice/extras/08-numbers.md
+++ b/novice/extras/08-numbers.md
@@ -25,9 +25,9 @@ if (length != +0) and (length != -0)
 
 As for the other problem,
 it turns out that the circuits needed to do addition and other arithmetic on this
-[sign and magnitude representation](../gloss.html#sign-and-magnitude)
+[sign and magnitude representation](../../gloss.html#sign-and-magnitude)
 are more complicated than the hardware needed for another called
-[two's complement](../gloss.html#twos-complement).
+[two's complement](../../gloss.html#twos-complement).
 Instead of mirroring positive values,
 two's complement rolls over when going below zero,
 just like a car's odometer.
@@ -52,7 +52,7 @@ numbers go from -8 to 7, or -16 to 15, and so on.
 As a result, even if `x` is a valid number, `-x` may not be.
 
 Finding a good representation for real numbers
-(called [floating point numbers](../gloss.html#floating-point),
+(called [floating point numbers](../../gloss.html#floating-point),
 since the decimal point can move around)
 is a much harder problem.
 The root of the problem is that
@@ -126,9 +126,9 @@ so that the ratio of the spacing to the values stays roughly constant.
 This happens because we're multiplying the same fixed set of mantissas by ever-larger exponents,
 and it points us at a couple of useful definitions.
 
-The [absolute error](../gloss.html#absolute-error) in some approximation
+The [absolute error](../../gloss.html#absolute-error) in some approximation
 is simply the absolute value of the difference between the actual value and the approximation.
-The [relative error](../gloss.html#relative-error),
+The [relative error](../../gloss.html#relative-error),
 on the other hand,
 is the ratio of the absolute error to the value we're approximating.
 For example, if we're off by 1 in approximating 8+1 and 56+1,

--- a/novice/git/00-intro.md
+++ b/novice/git/00-intro.md
@@ -13,7 +13,7 @@ each one will spend a lot of time waiting for the other to finish,
 but if they work on their own copies and email changes back and forth
 things will be lost, overwritten, or duplicated.
 
-The right solution is to use [version control](../gloss.html#version-control)
+The right solution is to use [version control](../../gloss.html#version-control)
 to manage their work.
 Version control is better than mailing files back and forth because:
 

--- a/novice/git/01-backup.md
+++ b/novice/git/01-backup.md
@@ -73,7 +73,7 @@ $ cd planets
 ~~~
 </div>
 
-and tell Git to make it a [repository](../gloss.html#repository)&mdash;a place where
+and tell Git to make it a [repository](../../gloss.html#repository)&mdash;a place where
 Git can store old versions of our files:
 
 <div class="in" markdown="1">
@@ -238,7 +238,7 @@ $ git commit -m "Starting to think about Mars"
 When we run `git commit`,
 Git takes everything we have told it to save by using `git add`
 and stores a copy permanently inside the special `.git` directory.
-This permanent copy is called a [revision](../../gloss.html#revision)
+This permanent copy is called a [revision](../../../gloss.html#revision)
 and its short identifier is `f22b25e`.
 (Your revision may have another identifier.)
 
@@ -370,7 +370,7 @@ If we can break it down into pieces:
 
 1.  The first line tells us that Git is using the Unix `diff` command
     to compare the old and new versions of the file.
-2.  The second line tells exactly which [revisions](../../gloss.html#revision) of the file
+2.  The second line tells exactly which [revisions](../../../gloss.html#revision) of the file
     Git is comparing;
     `df0654a` and `315bf3a` are unique computer-generated labels for those revisions.
 3.  The remaining lines show us the actual differences
@@ -429,7 +429,7 @@ but *not* commit the work we're doing on the conclusion
 To allow for this,
 Git has a special staging area
 where it keeps track of things that have been added to
-the current [change set](../gloss.html#change-set)
+the current [change set](../../gloss.html#change-set)
 but not yet committed.
 `git add` puts things in this area (the index),
 and `git commit` then copies them to long-term storage (as a commit):

--- a/novice/git/02-collab.md
+++ b/novice/git/02-collab.md
@@ -57,14 +57,14 @@ but the remote repository on GitHub doesn't contain any files yet:
 <img src="img/git-freshly-made-github-repo.svg" alt="Freshly-Made GitHub Repository" />
 
 The next step is to connect the two repositories.
-We do this by making the GitHub repository a [remote](../gloss.html#repository-remote)
+We do this by making the GitHub repository a [remote](../../gloss.html#repository-remote)
 for the local repository.
 The home page of the repository on GitHub includes
 the string we need to identify it:
 
 <img src="img/github-find-repo-string.png" alt="Where to Find Repository URL on GitHub" />
 
-Click on the 'HTTPS' link to change the [protocol](../../gloss.html#protocol) from SSH to HTTPS.
+Click on the 'HTTPS' link to change the [protocol](../../../gloss.html#protocol) from SSH to HTTPS.
 It's slightly less convenient for day-to-day use,
 but much less work for beginners to set up:
 
@@ -160,7 +160,7 @@ To do this,
 (Note the absolute path:
 don't make `tmp` a subdirectory of the existing repository).
 Instead of creating a new repository here with `git init`,
-we will [clone](../gloss.html#repository-clone) the existing repository from GitHub:
+we will [clone](../../gloss.html#repository-clone) the existing repository from GitHub:
 
 <div class="in" markdown="1">
 ~~~
@@ -289,7 +289,7 @@ to share work between different people and machines.
     clone it,
     add a file,
     push those changes to GitHub,
-    and then look at the [timestamp](../../gloss.html#timestamp) of the change on GitHub.
+    and then look at the [timestamp](../../../gloss.html#timestamp) of the change on GitHub.
     How does GitHub record times, and why?
 
 </div>

--- a/novice/git/03-conflict.md
+++ b/novice/git/03-conflict.md
@@ -16,8 +16,8 @@ someone's going to step on someone else's toes.
 This will even happen with a single person:
 if we are working on a piece of software on both our laptop and a server in the lab,
 we could make different changes to each copy.
-Version control helps us manage these [conflicts](../gloss.html#conflict)
-by giving us tools to [resolve](../gloss.html#resolve) overlapping changes.
+Version control helps us manage these [conflicts](../../gloss.html#conflict)
+by giving us tools to [resolve](../../gloss.html#resolve) overlapping changes.
 
 To see how we can resolve conflicts,
 we must first create one.
@@ -147,7 +147,7 @@ hint: See the 'Note about fast-forwards' in 'git push --help' for details.
 Git detects that the changes made in one copy overlap with those made in the other
 and stops us from trampling on our previous work.
 What we have to do is pull the changes from GitHub,
-[merge](../gloss.html#repository-merge) them into the copy we're currently working in,
+[merge](../../gloss.html#repository-merge) them into the copy we're currently working in,
 and then push that.
 Let's start by pulling:
 

--- a/novice/git/04-open.md
+++ b/novice/git/04-open.md
@@ -90,7 +90,7 @@ people can choose between the [GNU Public License](http://opensource.org/license
 and licenses like the [MIT](http://opensource.org/licenses/MIT)
 and [BSD](http://opensource.org/licenses/BSD-2-Clause) licenses on the other.
 All of these licenses allow unrestricted sharing and modification of programs,
-but the GPL is [infective](../gloss.html#infective-license):
+but the GPL is [infective](../../gloss.html#infective-license):
 anyone who distributes a modified version of the code
 (or anything that includes GPL'd code)
 must make *their* code freely available as well.
@@ -220,7 +220,7 @@ would like to be sure that data will still be available ten years from now,
 but that's well beyond the lifespan of most of the grants that fund academic infrastructure.
 
 Another option is to purchase a domain
-and pay an [Internet service provider](../../gloss.html#isp) (ISP) to host it.
+and pay an [Internet service provider](../../../gloss.html#isp) (ISP) to host it.
 This gives the individual or group more control,
 and sidesteps problems that can arise when moving from one institution to another,
 but requires more time and effort to set up than either


### PR DESCRIPTION
This should fix #393 applying the changes made by

```
$ for i in $(grep -lr -e "(../gloss.html" ./novice); do sed -i 's/\.\.\/gloss\.html/\.\.\/\.\.\/gloss\.html/' $i; done
$ for i in $(grep -lr -e "(../gloss.html" ./intermediate); do sed -i 's/\.\.\/gloss\.html/\.\.\/\.\.\/gloss\.html/' $i; done
```
