### PR TITLE
Fix broken links to glossary

### DIFF
--- a/novice/python/01-numpy.ipynb
+++ b/novice/python/01-numpy.ipynb
@@ -25,7 +25,7 @@
      "source": [
       "We are studying inflammation in patients who have been given a new treatment for arthritis,\n",
       "and need to analyze the first dozen data sets.\n",
-      "The data sets are stored in [comma-separated values](../../gloss.html#csv) (CSV) format:\n",
+      "The data sets are stored in [comma-separated values](../../gloss.md#csv) (CSV) format:\n",
       "each row holds information for a single patient,\n",
       "and the columns represent successive days.\n",
       "The first few rows of our first file look like this:\n",
@@ -91,10 +91,10 @@
       "but what's more useful are the sentences and stories we use them to build.\n",
       "Similarly,\n",
       "while a lot of powerful tools are built into languages like Python,\n",
-      "even more lives in the [libraries](../../gloss.html#library) they are used to build.\n",
+      "even more lives in the [libraries](../../gloss.md#library) they are used to build.\n",
       "\n",
       "In order to load our inflammation data,\n",
-      "we need to [import](../../gloss.html#import) a library called NumPy\n",
+      "we need to [import](../../gloss.md#import) a library called NumPy\n",
       "that knows how to operate on matrices:"
      ]
     },
@@ -157,15 +157,15 @@
       "cell_tags": []
      },
      "source": [
-      "The expression `numpy.loadtxt(...)` is a [function call](../../gloss.html#function-call)\n",
+      "The expression `numpy.loadtxt(...)` is a [function call](../../gloss.md#function-call)\n",
       "that asks Python to run the function `loadtxt` that belongs to the `numpy` library.\n",
-      "This [dotted notation](../../gloss.html#dotted-notation) is used everywhere in Python\n",
+      "This [dotted notation](../../gloss.md#dotted-notation) is used everywhere in Python\n",
       "to refer to the parts of things as `whole.part`.\n",
       "\n",
-      "`numpy.loadtxt` has two [parameters](../../gloss.html#parameter):\n",
+      "`numpy.loadtxt` has two [parameters](../../gloss.md#parameter):\n",
       "the name of the file we want to read,\n",
-      "and the [delimiter](../../gloss.html#delimiter) that separates values on a line.\n",
-      "These both need to be character strings (or [strings](../../gloss.html#string) for short),\n",
+      "and the [delimiter](../../gloss.md#delimiter) that separates values on a line.\n",
+      "These both need to be character strings (or [strings](../../gloss.md#string) for short),\n",
       "so we put them in quotes.\n",
       "\n",
       "When we are finished typing and press Shift+Enter,\n",
@@ -191,7 +191,7 @@
       "Our call to `numpy.loadtxt` read our file,\n",
       "but didn't save the data in memory.\n",
       "To do that,\n",
-      "we need to [assign](../../gloss.html#assignment) the array to a [variable](../../gloss.html#variable).\n",
+      "we need to [assign](../../gloss.md#assignment) the array to a [variable](../../gloss.md#variable).\n",
       "A variable is just a name for a value,\n",
       "such as `x`, `current_temperature`, or `subject_id`.\n",
       "We can create a new variable simply by assigning a value to it using `=`:"
@@ -512,7 +512,7 @@
       "Now that our data is in memory,\n",
       "we can start doing things with it.\n",
       "First,\n",
-      "let's ask what [type](../../gloss.html#data-type) of thing `data` refers to:"
+      "let's ask what [type](../../gloss.md#data-type) of thing `data` refers to:"
      ]
     },
     {
@@ -543,7 +543,7 @@
      },
      "source": [
       "The output tells us that `data` currently refers to an N-dimensional array created by the NumPy library.\n",
-      "We can see what its [shape](../../gloss.html#shape) is like this:"
+      "We can see what its [shape](../../gloss.md#shape) is like this:"
      ]
     },
     {
@@ -574,7 +574,7 @@
      },
      "source": [
       "This tells us that `data` has 60 rows and 40 columns.\n",
-      "`data.shape` is a [member](../../gloss.html#member) of `data`,\n",
+      "`data.shape` is a [member](../../gloss.md#member) of `data`,\n",
       "i.e.,\n",
       "a value that is stored as part of a larger value.\n",
       "We use the same dotted notation for the members of values\n",
@@ -589,7 +589,7 @@
      },
      "source": [
       "If we want to get a single value from the matrix,\n",
-      "we must provide an [index](../../gloss.html#index) in square brackets,\n",
+      "we must provide an [index](../../gloss.md#index) in square brackets,\n",
       "just as we do in math:"
      ]
     },
@@ -708,7 +708,7 @@
       "cell_tags": []
      },
      "source": [
-      "The [slice](../../gloss.html#slice) `0:4` means,\n",
+      "The [slice](../../gloss.md#slice) `0:4` means,\n",
       "\"Start at index 0 and go up to, but not including, index 4.\"\n",
       "Again,\n",
       "the up-to-but-not-including takes a bit of getting used to,\n",
@@ -748,7 +748,7 @@
       "cell_tags": []
      },
      "source": [
-      "and we don't have to take all the values in the slice---if we provide a [stride](../../gloss.html#stride),\n",
+      "and we don't have to take all the values in the slice---if we provide a [stride](../../gloss.md#stride),\n",
       "Python takes values spaced that far apart:"
      ]
     },
@@ -870,7 +870,7 @@
       "cell_tags": []
      },
      "source": [
-      "`mean` is a [method](../../gloss.html#method) of the array,\n",
+      "`mean` is a [method](../../gloss.md#method) of the array,\n",
       "i.e.,\n",
       "a function that belongs to it\n",
       "in the same way that the member `shape` does.\n",
@@ -1128,7 +1128,7 @@
      "source": [
       "#### Challenges\n",
       "\n",
-      "A subsection of an array is called a [slice](../../gloss.html#slice).\n",
+      "A subsection of an array is called a [slice](../../gloss.md#slice).\n",
       "We can take slices of character strings as well:"
      ]
     },
@@ -1175,7 +1175,7 @@
       "    Given those answers,\n",
       "    explain what `element[1:-1]` does.\n",
       "\n",
-      "1.  The expression `element[3:3]` produces an [empty string](../../gloss.html#empty-string),\n",
+      "1.  The expression `element[3:3]` produces an [empty string](../../gloss.md#empty-string),\n",
       "    i.e., a string that contains no characters.\n",
       "    If `data` holds our array of patient data,\n",
       "    what does `data[3:3, 4:4]` produce?\n",
@@ -1405,7 +1405,7 @@
       "cell_tags": []
      },
      "source": [
-      "It's very common to create an [alias](../../gloss.html#alias-library) for a library when importing it\n",
+      "It's very common to create an [alias](../../gloss.md#alias-library) for a library when importing it\n",
       "in order to reduce the amount of typing we have to do.\n",
       "Here are our three plots side by side using aliases for `numpy` and `pyplot`:"
      ]


### PR DESCRIPTION
I guess `gloss.html` was converted to `gloss.md` meanwhile.
I remember discussions about Markdown vs HTML :)
