### PR TITLE
Fix links to glossary

### DIFF
--- a/novice/extras/06-ssh.md
+++ b/novice/extras/06-ssh.md
@@ -200,7 +200,7 @@ and sends the output back to our local shell for display.
 > Typing our password over and over again is annoying,
 > especially if the commands we want to run remotely are in a loop.
 > To remove the need to do this,
-> we can create an [authentication key](../../../gloss.html#authentication-key)
+> we can create an [authentication key](../../gloss.html#authentication-key)
 > to tell the remote machine
 > that it should always trust us.
 > We discuss authentication keys in our intermediate lessons.

--- a/novice/git/01-backup.md
+++ b/novice/git/01-backup.md
@@ -238,7 +238,7 @@ $ git commit -m "Starting to think about Mars"
 When we run `git commit`,
 Git takes everything we have told it to save by using `git add`
 and stores a copy permanently inside the special `.git` directory.
-This permanent copy is called a [revision](../../../gloss.html#revision)
+This permanent copy is called a [revision](../../gloss.html#revision)
 and its short identifier is `f22b25e`.
 (Your revision may have another identifier.)
 
@@ -370,7 +370,7 @@ If we can break it down into pieces:
 
 1.  The first line tells us that Git is using the Unix `diff` command
     to compare the old and new versions of the file.
-2.  The second line tells exactly which [revisions](../../../gloss.html#revision) of the file
+2.  The second line tells exactly which [revisions](../../gloss.html#revision) of the file
     Git is comparing;
     `df0654a` and `315bf3a` are unique computer-generated labels for those revisions.
 3.  The remaining lines show us the actual differences

--- a/novice/git/02-collab.md
+++ b/novice/git/02-collab.md
@@ -64,7 +64,7 @@ the string we need to identify it:
 
 <img src="img/github-find-repo-string.png" alt="Where to Find Repository URL on GitHub" />
 
-Click on the 'HTTPS' link to change the [protocol](../../../gloss.html#protocol) from SSH to HTTPS.
+Click on the 'HTTPS' link to change the [protocol](../../gloss.html#protocol) from SSH to HTTPS.
 It's slightly less convenient for day-to-day use,
 but much less work for beginners to set up:
 
@@ -289,7 +289,7 @@ to share work between different people and machines.
     clone it,
     add a file,
     push those changes to GitHub,
-    and then look at the [timestamp](../../../gloss.html#timestamp) of the change on GitHub.
+    and then look at the [timestamp](../../gloss.html#timestamp) of the change on GitHub.
     How does GitHub record times, and why?
 
 </div>

--- a/novice/git/04-open.md
+++ b/novice/git/04-open.md
@@ -220,7 +220,7 @@ would like to be sure that data will still be available ten years from now,
 but that's well beyond the lifespan of most of the grants that fund academic infrastructure.
 
 Another option is to purchase a domain
-and pay an [Internet service provider](../../../gloss.html#isp) (ISP) to host it.
+and pay an [Internet service provider](../../gloss.html#isp) (ISP) to host it.
 This gives the individual or group more control,
 and sidesteps problems that can arise when moving from one institution to another,
 but requires more time and effort to set up than either


### PR DESCRIPTION
@r-gaia-cs brokes some links with #394. This fix this links.

```
$ for i in $(grep -rl '../../../gloss.html' novice)
do sed -i 's@../../../gloss@../../gloss@' $i
done
$ grep -re '../../../gloss.html' novice
$ grep -re '../../../gloss.html' intermediate
```

Thanks to @lexnederbragt.
