### PR TITLE
Fix to Missing Plots at Python Lesson

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,6 @@ $(BOOK_MD) : $(PAGES_SRC) bin/make-book.py
 # Markdown files triggers the desired build once and only once.
 $(INDEX) : $(BOOK_MD) $(CONFIG) $(EXTRAS)
 	jekyll -t build -d $(SITE)
-	rm -rf $(SITE)/novice/*/??-*_files
 
 #----------------------------------------------------------------------
 # Targets.

--- a/_templates/ipynb.tpl
+++ b/_templates/ipynb.tpl
@@ -28,7 +28,15 @@ root: ../..
 
 {%- block data_jpg -%}<img src="../../{{ output.jpeg_filename | path2url }}">{%- endblock data_jpg -%}
 
-{%- block display_data -%}{{- output.html -}}{%- endblock display_data -%}
+{%- block data_text -%}{{ output.html }}{%- endblock data_text -%}
+
+{%- block display_data -%}
+{%- if output.html -%}
+{{- output.html -}}
+{%- else -%}
+{{- super() -}}
+{%- endif -%}
+{%- endblock display_data -%}
 
 {% block markdowncell %}
 {% if 'cell_tags' in cell.metadata %}


### PR DESCRIPTION
This fix #402.

In this PR I don't update the markdown files generate from IPython Notebook.

```
$ make site
$ git diff --name-only
intermediate/python/01-intro-python.md
intermediate/python/02-modularization-documentation.md
novice/python/01-numpy.md
novice/python/02-func.md
novice/python/03-loop.md
novice/python/04-cond.md
novice/sql/01-select.md
novice/sql/04-calc.md
```

I don't update the markdown files because I don't like very much the path to the plots:

```
$ git diff -- novice/python/01-numpy.md | head -n 15
diff --git a/novice/python/01-numpy.md b/novice/python/01-numpy.md
index e87745d..f02ecba 100644
--- a/novice/python/01-numpy.md
+++ b/novice/python/01-numpy.md
@@ -577,7 +577,9 @@ pyplot.show()</pre>
 </div>

 <div class="out">
-<pre></pre>
+<pre>
+<img src="../../novice/python/01-numpy_files/novice/python/01-numpy_74_0.png">
+</pre>
 </div>

```

I try to improve the path to the plots but have some troubles due ipython/ipython#5529. I want to wait some time for comments in IPython issue before go ahead with this PR.
