### PR TITLE
Using the word 'parameter' instead of the word 'argument' in most places.

### DIFF
--- a/novice/extras/06-ssh.md
+++ b/novice/extras/06-ssh.md
@@ -189,8 +189,9 @@ results-2011-10-04.dat  results-2011-11-11.dat
 </div>
 
 SSH takes the argument after our remote username
-and passes them to the shell on the remote computer.
-(We have to put quotes around it to make it look like a single argument.)
+and passes it to the shell on the remote computer.
+(We put quotes around the two words `ls` and `results`
+so that the shell will think of them as a single string.)
 Since those arguments are a legal command,
 the remote shell runs `ls results` for us
 and sends the output back to our local shell for display.

--- a/novice/python/02-func.ipynb
+++ b/novice/python/02-func.ipynb
@@ -1331,7 +1331,7 @@
      },
      "source": [
       "The key change is that the second parameter is now written `desired=0.0` instead of just `desired`.\n",
-      "If we call the function with two arguments,\n",
+      "If we call the function with two parameters,\n",
       "it works as it did before:"
      ]
     },

--- a/novice/python/02-func.md
+++ b/novice/python/02-func.md
@@ -623,7 +623,7 @@ TypeError: data type &#34;,&#34; not understood</pre>
 
 
 <div class="">
-<p>The key change is that the second parameter is now written <code>desired=0.0</code> instead of just <code>desired</code>. If we call the function with two arguments, it works as it did before:</p>
+<p>The key change is that the second parameter is now written <code>desired=0.0</code> instead of just <code>desired</code>. If we call the function with two parameters, it works as it did before:</p>
 </div>
 
 

--- a/novice/python/03-loop.ipynb
+++ b/novice/python/03-loop.ipynb
@@ -859,7 +859,7 @@
      "source": [
       "#### Challenges\n",
       "\n",
-      "1.  Write a function called `analyze_all` that takes a filename pattern as its sole argument\n",
+      "1.  Write a function called `analyze_all` that takes a filename pattern as its sole parameter\n",
       "    and runs `analyze` for each file whose name matches the pattern."
      ]
     },

--- a/novice/python/03-loop.md
+++ b/novice/python/03-loop.md
@@ -391,7 +391,7 @@ inflammation-03.csv
 <div class="challenges">
 <h4 id="challenges">Challenges</h4>
 <ol style="list-style-type: decimal">
-<li>Write a function called <code>analyze_all</code> that takes a filename pattern as its sole argument and runs <code>analyze</code> for each file whose name matches the pattern.</li>
+<li>Write a function called <code>analyze_all</code> that takes a filename pattern as its sole parameter and runs <code>analyze</code> for each file whose name matches the pattern.</li>
 </ol>
 </div>
 

--- a/novice/python/06-cmdline.ipynb
+++ b/novice/python/06-cmdline.ipynb
@@ -62,7 +62,7 @@
       "3. Use the `--min`, `--mean`, or `--max` flag to determine what statistic to print.\n",
       "\n",
       "To make this work,\n",
-      "we need to know how to handle command-line arguments in a program,\n",
+      "we need to know how to handle command-line parameters in a program,\n",
       "and how to get at standard input.\n",
       "We'll tackle these questions in turn below."
      ]
@@ -77,7 +77,7 @@
      "source": [
       "#### Objectives\n",
       "\n",
-      "*   Use the values of command-line arguments in a program.\n",
+      "*   Use the values of command-line parameters in a program.\n",
       "*   Handle flags and files separately in a command-line program.\n",
       "*   Read data from standard input in a program so that it can be used in a pipeline."
      ]
@@ -241,7 +241,8 @@
      },
      "source": [
       "The strange name `argv` stands for \"argument values\".\n",
-      "Whenever Python runs a program,\n",
+      "\"Argument\" is just a synonym for \"parameter\";\n",
+      "whenever Python runs a program,\n",
       "it takes all of the values given on the command line\n",
       "and puts them in the list `sys.argv`\n",
       "so that the program can determine what they were.\n",

--- a/novice/python/06-cmdline.md
+++ b/novice/python/06-cmdline.md
@@ -26,14 +26,14 @@ root: ../..
 <li>If one or more filenames are given, read data from them and report statistics for each file separately.</li>
 <li>Use the <code>--min</code>, <code>--mean</code>, or <code>--max</code> flag to determine what statistic to print.</li>
 </ol>
-<p>To make this work, we need to know how to handle command-line arguments in a program, and how to get at standard input. We'll tackle these questions in turn below.</p>
+<p>To make this work, we need to know how to handle command-line parameters in a program, and how to get at standard input. We'll tackle these questions in turn below.</p>
 </div>
 
 
 <div class="objectives">
 <h4 id="objectives">Objectives</h4>
 <ul>
-<li>Use the values of command-line arguments in a program.</li>
+<li>Use the values of command-line parameters in a program.</li>
 <li>Handle flags and files separately in a command-line program.</li>
 <li>Read data from standard input in a program so that it can be used in a pipeline.</li>
 </ul>
@@ -112,7 +112,7 @@ print &#39;sys.argv is&#39;, sys.argv
 
 
 <div class="">
-<p>The strange name <code>argv</code> stands for &quot;argument values&quot;. Whenever Python runs a program, it takes all of the values given on the command line and puts them in the list <code>sys.argv</code> so that the program can determine what they were. If we run this program with no arguments:</p>
+<p>The strange name <code>argv</code> stands for &quot;argument values&quot;. &quot;Argument&quot; is just a synonym for &quot;parameter&quot;; whenever Python runs a program, it takes all of the values given on the command line and puts them in the list <code>sys.argv</code> so that the program can determine what they were. If we run this program with no arguments:</p>
 </div>
 
 

--- a/novice/r/00-first-timers.Rmd
+++ b/novice/r/00-first-timers.Rmd
@@ -54,7 +54,7 @@ __Package management__
 
 `install.packages("package-name")` will download a package from one of the CRAN mirrors assuming that a binary is available for your operating system. If you have not set a preferred CRAN mirror in your options(), then a menu will pop up asking you to choose a location.
 
-Use `old.packages()` to list all your locally installed packages that are now out of date. `update.packages()` will update all packages in the known libraries interactively. This can take a while if you haven't done it recently. To update everything without any user intervention, use the `ask = FALSE` argument.
+Use `old.packages()` to list all your locally installed packages that are now out of date. `update.packages()` will update all packages in the known libraries interactively. This can take a while if you haven't done it recently. To update everything without any user intervention, use the `ask = FALSE` parameter.
 
 ```{r, eval=FALSE}
 update.packages(ask = FALSE)
@@ -314,7 +314,7 @@ cbind(x, y)
 rbind(x, y)
 ```
 
-You can also use the byrow argument to specify how the matrix is filled. From R's own documentation:
+You can also use the byrow parameter to specify how the matrix is filled. From R's own documentation:
 
 ```{r}
 mdat <- matrix(c(1,2,3, 11,12,13), nrow = 2, ncol = 3, byrow = TRUE,

--- a/novice/r/00-first-timers.md
+++ b/novice/r/00-first-timers.md
@@ -59,7 +59,7 @@ __Package management__
 
 `install.packages("package-name")` will download a package from one of the CRAN mirrors assuming that a binary is available for your operating system. If you have not set a preferred CRAN mirror in your options(), then a menu will pop up asking you to choose a location.
 
-Use `old.packages()` to list all your locally installed packages that are now out of date. `update.packages()` will update all packages in the known libraries interactively. This can take a while if you haven't done it recently. To update everything without any user intervention, use the `ask = FALSE` argument.
+Use `old.packages()` to list all your locally installed packages that are now out of date. `update.packages()` will update all packages in the known libraries interactively. This can take a while if you haven't done it recently. To update everything without any user intervention, use the `ask = FALSE` parameter.
 
 
 ```r
@@ -365,7 +365,7 @@ rbind(x, y)
 ```
 
 
-You can also use the byrow argument to specify how the matrix is filled. From R's own documentation:
+You can also use the byrow parameter to specify how the matrix is filled. From R's own documentation:
 
 
 ```r

--- a/novice/r/01-starting-with-data.Rmd
+++ b/novice/r/01-starting-with-data.Rmd
@@ -132,7 +132,7 @@ age  <- age - 20
 ```
 
 We can also add to variable that are vectors, and update them by making them longer. 
-For example, if we are creating a vector of patient weights, we could update that vector using `append`. `append` takes two arguments, and adds the second item to the end of the first one.
+For example, if we are creating a vector of patient weights, we could update that vector using `append`. `append` takes two parameters, and adds the second item to the end of the first one.
 
 ```{r}
 weights <- c(100)
@@ -291,7 +291,7 @@ cbind(x, y)
 rbind(x, y)
 ```
 
-You can also use the byrow argument to specify how the matrix is filled. From R's own documentation:
+You can also use the byrow parameter to specify how the matrix is filled. From R's own documentation:
 
 ```{r}
 mdat <- matrix(c(1,2,3, 11,12,13), nrow = 2, ncol = 3, byrow = TRUE,

--- a/novice/r/01-starting-with-data.md
+++ b/novice/r/01-starting-with-data.md
@@ -150,7 +150,7 @@ age <- age - 20
 
 
 We can also add to variable that are vectors, and update them by making them longer. 
-For example, if we are creating a vector of patient weights, we could update that vector using `append`. `append` takes two arguments, and adds the second item to the end of the first one.
+For example, if we are creating a vector of patient weights, we could update that vector using `append`. `append` takes two parameters, and adds the second item to the end of the first one.
 
 
 ```r
@@ -337,7 +337,7 @@ rbind(x, y)
 ```
 
 
-You can also use the byrow argument to specify how the matrix is filled. From R's own documentation:
+You can also use the byrow parameter to specify how the matrix is filled. From R's own documentation:
 
 
 ```r

--- a/novice/r/02-func-R.Rmd
+++ b/novice/r/02-func-R.Rmd
@@ -323,7 +323,7 @@ center <- function(data, desired=0){
 }
 ```
 
-The key change is that the second parameter is now written `desired=0` instead of just `desired`. If we call the function with two arguments, it works as it did before:
+The key change is that the second parameter is now written `desired=0` instead of just `desired`. If we call the function with two parameters, it works as it did before:
 
 ```{r}
 test_data <- matrix(0,2,2)

--- a/novice/r/02-func-R.md
+++ b/novice/r/02-func-R.md
@@ -382,7 +382,7 @@ center <- function(data, desired = 0) {
 ```
 
 
-The key change is that the second parameter is now written `desired=0` instead of just `desired`. If we call the function with two arguments, it works as it did before:
+The key change is that the second parameter is now written `desired=0` instead of just `desired`. If we call the function with two parameters, it works as it did before:
 
 
 ```r

--- a/novice/r/03-loops-R.Rmd
+++ b/novice/r/03-loops-R.Rmd
@@ -260,7 +260,7 @@ Sure enough, the maxima of these data sets show exactly the same ramp as the fir
 
 ### Challenges
 
-1. Write a function called `analyze_all` that takes a filename pattern as its sole argument and runs analyze for each file whose name matches the pattern.
+1. Write a function called `analyze_all` that takes a filename pattern as its sole parameter and runs analyze for each file whose name matches the pattern.
 
 ## Key Points
 

--- a/novice/r/03-loops-R.md
+++ b/novice/r/03-loops-R.md
@@ -307,7 +307,7 @@ Sure enough, the maxima of these data sets show exactly the same ramp as the fir
 
 ### Challenges
 
-1. Write a function called `analyze_all` that takes a filename pattern as its sole argument and runs analyze for each file whose name matches the pattern.
+1. Write a function called `analyze_all` that takes a filename pattern as its sole parameter and runs analyze for each file whose name matches the pattern.
 
 ## Key Points
 

--- a/novice/r/04-cond-colors-R.Rmd
+++ b/novice/r/04-cond-colors-R.Rmd
@@ -35,7 +35,7 @@ grid1 <- block_grid(5, type = "vector")
 grid1
 ```
 
-We can see that this grid represents a vector. It is a single dimension and has 5 locations (which we gave to it in the first argument). We can see the summarized information in the grid:
+We can see that this grid represents a vector. It is a single dimension and has 5 locations (which we gave to it in the first parameter). We can see the summarized information in the grid:
 
 ```{r}
 str(grid1)

--- a/novice/r/04-cond-colors-R.md
+++ b/novice/r/04-cond-colors-R.md
@@ -40,7 +40,7 @@ grid1
 ![plot of chunk unnamed-chunk-3](figure/unnamed-chunk-3.png) 
 
 
-We can see that this grid represents a vector. It is a single dimension and has 5 locations (which we gave to it in the first argument). We can see the summarized information in the grid:
+We can see that this grid represents a vector. It is a single dimension and has 5 locations (which we gave to it in the first parameter). We can see the summarized information in the grid:
 
 
 ```r

--- a/novice/sql/08-create.ipynb
+++ b/novice/sql/08-create.ipynb
@@ -44,7 +44,7 @@
       "While they are written as two words,\n",
       "they are actually single commands.\n",
       "The first one creates a new table;\n",
-      "its arguments are the names and types of the table's columns.\n",
+      "its parameters are the names and types of the table's columns.\n",
       "For example,\n",
       "the following statements create the four tables in our survey database:\n",
       "\n",

--- a/novice/sql/08-create.md
+++ b/novice/sql/08-create.md
@@ -17,7 +17,7 @@ root: ../..
 
 <div>
 <p>So far we have only looked at how to get information out of a database, both because that is more frequent than adding information, and because most other operations only make sense once queries are understood. If we want to create and modify data, we need to know two other pairs of commands.</p>
-<p>The first pair are <code>create table</code> and <code>drop table</code>. While they are written as two words, they are actually single commands. The first one creates a new table; its arguments are the names and types of the table's columns. For example, the following statements create the four tables in our survey database:</p>
+<p>The first pair are <code>create table</code> and <code>drop table</code>. While they are written as two words, they are actually single commands. The first one creates a new table; its parameters are the names and types of the table's columns. For example, the following statements create the four tables in our survey database:</p>
 <pre><code>create table Person(ident text, personal text, family text);
 create table Site(name text, lat real, long real);
 create table Visited(ident integer, site text, dated text);


### PR DESCRIPTION
We have been inconsistent in our use of the words 'parameter' and 'argument'. Most scientists are more familiar with the first than the second, so this PR changes all uses of 'argument' in code to 'parameter'.  However, uses of the word 'argument' for command-line shell arguments are unchanged, since:
1.  that's what man pages call them, and
2.  `argv` is easier to explain if we use the word "argument".
