### PR TITLE
Add link to older installers for Git for OS X

### DIFF
--- a/_includes/setup.html
+++ b/_includes/setup.html
@@ -142,8 +142,12 @@
     </p>
     <h4>Git</h4>
     <p>
-      Install Git for Mac by download and running
-      <a href="http://git-scm.com/downloads">the installer</a>.
+      Install Git for Mac by downloading and running
+      <a href="http://git-scm.com/downloads">the installer</a>.  For older
+      versions of OS X (10.5-10.7) use the most recent available
+      installer <a href="https://code.google.com/p/git-osx-installer/downloads/list">available
+      here</a>. Use the Leopard installer for 10.5 and the Snow Leopard
+      installer for 10.6-10.7.
     </p>
   </div>
   <div class="span6">


### PR DESCRIPTION
The current Git installer for OS X is broken for many pre-10.8
systems. The older installers seem to solve this problem.

Also fixes a typo.
