### PR TITLE
Tell people what to type into the mars.txt file.

### DIFF
--- a/novice/git/01-backup.md
+++ b/novice/git/01-backup.md
@@ -141,6 +141,14 @@ $ nano mars.txt
 ~~~
 </div>
 
+Type the text below into the `mars.txt` file:
+
+<div class="in" markdown="1">
+~~~
+Cold and dry, but everything is my favorite color
+~~~
+</div>
+
 `mars.txt` now contains a single line:
 
 <div class="in" markdown="1">


### PR DESCRIPTION
I was referring back to this file for context to make a branching lesson and noticed there was no prompt to add the text being subsequently referred to in the 'mars.txt' file. This may confuse students or add an extra step for instructors, so it seemed right to amend it.
