### PR TITLE
setup/README.md: Convert 'boot camp' -> 'workshop'

### DIFF
--- a/setup/README.md
+++ b/setup/README.md
@@ -8,7 +8,7 @@ Students
 ========
 
 This directory contains scripts for testing your machine to make sure
-you have the software you'll need for your bootcamp installed.  See
+you have the software you'll need for your workshop installed.  See
 the comments at the head of each script for more details, but you'll
 basically want to see something like:
 
@@ -60,16 +60,16 @@ they'll be able to parse `swc-installation-test-2.py`.  The latter
 checks for a list of dependencies and prints error messages if a
 package is not installed, or if the installed version is not current
 enough.  By default, the script checks for pretty much anything that
-has ever been used at a Software Carpentry bootcamp, which is
-probably not what you want for your particular bootcamp.
+has ever been used at a Software Carpentry workshop, which is probably
+not what you want for your particular workshop.
 
-Before your bootcamp, you should go through
+Before your workshop, you should go through
 `swc-installation-test-2.py` and comment any dependencies you don't
 need out of the `CHECKS` list.  You might also want to skim through
 the minimum version numbers listed where particular dependencies are
 defined (e.g. `('git', 'Git', (1, 7, 0), None)`).  For the most part,
 fairly conservative values have been selected, so students with modern
-machines should be fine.  If your bootcamp has stricter version
+machines should be fine.  If your workshop has stricter version
 requirements, feel free to bump them accordingly.
 
 Similarly, the virtual dependencies can be satisfied by any of several


### PR DESCRIPTION
Following Amy Brown's [1](https://github.com/swcarpentry/bc/issues/240):

> We borrowed the "bootcamp" terminology from Hacker Within and also
> various fitness training camps, but as we branch out into parts of
> the world with a more violent recent history I'm less comfortable
> with the term.

The consensus on that issue was to change back to our old 'workshop' terminology.  The bulk of the swcarpentry/bc repository hasn't made the shift yet, but there's no reason I can't embrace the future here ;).
