### PR TITLE
Adding a bit more on ${var} in novice/shell/04-loop

### DIFF
--- a/novice/shell/04-loop.md
+++ b/novice/shell/04-loop.md
@@ -279,7 +279,7 @@ mv unicorn.dat original-unicorn.dat
 > you're still learning how loops work.
 
 Now that we have our files renamed with the prefix "original-",
-let's reverse course and take off the text.
+let's reverse course and take off the prefix.
 By placing the variable's name within curly braces, e.g., `${filename}`,
 you gain new powers&mdash;like the ability to modify the variable's value when you extract it.
 
@@ -302,7 +302,7 @@ mv original-unicorn.dat unicorn.dat
 ~~~
 </div>
 
-And by using `%` instead of `#` removes text from the end:
+And using `%` instead of `#` removes text from the end:
 
 <div class="in" markdown="1">
 ~~~
@@ -325,7 +325,7 @@ mv original-unicorn.dat original-unicorn
 > #### Avoid confusing variable names and text
 > 
 > Sometimes you may want to add something to the end of a variable's value.
-> For example, you might add "backup" to the end of your filenames:
+> For example, you might add "backup" to the end of your files' names:
 > 
 > ~~~
 > for filename in *.dat


### PR DESCRIPTION
For Teaching round 8.5, this pull request adds some simple uses of parameter expansion to the lesson novice/shell/04-loop.

After starting the lesson material I discovered that there is some discussion of parameter expansion in the old shell lessons (lessons/swc-shell/tutorial.html). I'm guessing this was dropped based on teaching experience, which made me rethink what I was working on. The old lesson materials explicitly refer to parameter expansion and tried to introduce find/replace:

```
mv $filename ${filename/.dat/-original.dat/}
```

which replaces the longest string match. So I completely avoided the probably confusing "parameter expansion," and introduced text removal and separating variable names and text, which are a bit simpler and fit most use cases. E.g.:

```
mv $filename ${filename#original-}
mv $filename ${filename%.dat}
mv $filename ${filename}backup
```
