### PR TITLE
Remove link to nonexistant lesson

### DIFF
--- a/novice/python/index.md
+++ b/novice/python/index.md
@@ -29,6 +29,5 @@ and to use that language *well*.
 4.  [Making Choices](04-cond.html)
 5.  [Defensive Programming](05-defensive.html)
 6.  [Command-Line Programs](06-cmdline.html)
-7.  [Working With Climate Data](07-climate.html)
 
 </div>


### PR DESCRIPTION
This link 404's, no such lesson, remove the link.
