### PR TITLE
Making variable name casing consistent in R example.

### DIFF
--- a/novice/r/02-func-R.Rmd
+++ b/novice/r/02-func-R.Rmd
@@ -60,8 +60,8 @@ Now that we've seen how to turn Fahrenheit into Kelvin, it's easy to turn Kelvin
 
 ```{r}
 kelvin_to_celsius <- function(temp) {
-    Celsius <- temp - 273.15
-	Celsius
+    celsius <- temp - 273.15
+	celsius
 }
 
 paste('absolute zero in Celsius:', kelvin_to_celsius(0))

--- a/novice/r/02-func-R.md
+++ b/novice/r/02-func-R.md
@@ -68,8 +68,8 @@ Now that we've seen how to turn Fahrenheit into Kelvin, it's easy to turn Kelvin
 
 ```r
 kelvin_to_celsius <- function(temp) {
-    Celsius <- temp - 273.15
-    Celsius
+    celsius <- temp - 273.15
+    celsius
 }
 
 paste("absolute zero in Celsius:", kelvin_to_celsius(0))


### PR DESCRIPTION
The variable 'celsius' was spelled 'Celsius' for no apparent reason in the novice R material.  This PR makes it consistently lower-case.
