### PR TITLE
Fix links to glossary at book.html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ BOOK_MD = ./book.md
 $(BOOK_MD) : $(MOST_SRC) bin/make-book.py
 	python bin/make-book.py $(MOST_SRC) > $@
 	sed -i 's/\.\.\/\.\.\/gloss.html#/#g:/g' $@
+	sed -i 's/\.\.\/\.\.\/rules.html#/#/g' $@
 
 #----------------------------------------------------------------------
 # Targets.


### PR DESCRIPTION
@gvwilson Could you take a look on it?

Originally the glossary is available at
http://software-carpentry.org/v5/gloss.html but for
software-carpentry.org/v5/book.html we is already available at
this document and we NEED make the links point to it (and not
http://software-carpentry.org/v5/gloss.html) to avoid problems
when creating the EPUB and PDF version of our lessons.
