### PR TITLE
Putting books before papers

### DIFF
--- a/bib.md
+++ b/bib.md
@@ -5,117 +5,43 @@ title: Recommended Reading
 ---
 ## Books
 
-*   Susan A. Ambrose, Michael W. Bridges, Michele DiPietro, Marsha C. Lovett, and Marie K. Norman:
-    *[How Learning Works: Seven Research-Based Principles for Smart Teaching](http://www.amazon.com/How-Learning-Works-Research-Based-Principles/dp/0470484101/)*.
-    Jossey-Bass,
-    2010,
-    978-0470484104.
+Susan A. Ambrose, Michael W. Bridges, Michele DiPietro, Marsha C. Lovett, and Marie K. Norman: *[How Learning Works: Seven Research-Based Principles for Smart Teaching](http://www.amazon.com/How-Learning-Works-Research-Based-Principles/dp/0470484101/)*. Jossey-Bass, 2010, 978-0470484104.
+:   The best single-volume guide to evidence-based practices in education around.
 
-    The best single-volume guide to evidence-based practices in education around.
+Chris Fehily: *SQL: Visual QuickStart Guide* (3rd ed). Peachpit Press, 0321553578, 2002.
+:   Describes the 5% of SQL that covers 95% of real-world needs.
 
-*   Chris Fehily:
-    *SQL: Visual QuickStart Guide* (3rd ed).
-    Peachpit Press,
-    0321553578,
-    2002.
+Karl Fogel: *Producing Open Source Software: How to Run a Successful Free Software Project*. O'Reilly Media, 0596007590, 2005.
+:   An guide to how open source projects actually work, full of practical advice on how to earn commit privileges on a project, get it more attention, or fork it in case of irreconcilable differences.
 
-    Describes the 5% of SQL that covers 95% of real-world needs.
+Steve Haddock and Casey Dunn: *Practical Computing for Biologists*. Sinauer, 0878933913, 2010.
+:   An excellent general introduction to "the other 90%" of scientific computing.
 
-*   Karl Fogel:
-    *Producing Open Source Software: How to Run a Successful Free Software Project*.
-    O'Reilly Media,
-    0596007590,
-    2005.
+Andy Oram and Greg Wilson (eds): *Making Software: What Really Works, and Why We Believe It*. O'Reilly, 0596808321, 2010.
+:   Leading software engineering researchers take a chapter each to describe key empirical results and the evidence behind them. Topics range from the impact of programming languages on programmers' productivity to whether we can predict software faults using statistical techniques.
 
-    An excellent guide to how open source projects actually work.
-    Every page offers practical advice on how to earn commit privileges on a project,
-    get it more attention,
-    or fork it in case of irreconcilable differences.
-
-*   Steve Haddock and Casey Dunn:
-    *Practical Computing for Biologists*.
-    Sinauer,
-    0878933913,
-    2010.
-
-    An excellent general introduction to "the other 90%" of scientific computing.
-
-*   Andy Oram and Greg Wilson (eds):
-    *Making Software: What Really Works, and Why We Believe It*.
-    O'Reilly,
-    0596808321,
-    2010.
-
-    Leading software engineering researchers take a chapter each
-    to describe key empirical results and the evidence behind them.
-    Topics range from the impact of programming languages on programmers' productivity
-    to whether we can predict software faults using statistical techniques.
-
-*   Deborah S. Ray and Eric J. Ray:
-    *Unix and Linux: Visual QuickStart Guide*.
-    Peachpit Press,
-    0321636783,
-    2009.
-
-    A gentle introduction to Unix, with many examples.
+Deborah S. Ray and Eric J. Ray: *Unix and Linux: Visual QuickStart Guide*. Peachpit Press, 0321636783, 2009.
+:   A gentle introduction to Unix, with many examples.
 
 ## Papers
 
-*   Paul F. Dubois:
-    "Maintaining Correctness in Scientific Programs".
-    *Computing in Science & Engineering*,
-    May–June 2005.
+Paul F. Dubois: "Maintaining Correctness in Scientific Programs". *Computing in Science & Engineering*, May–June 2005.
+:   Shows how several good programming practices fit together to create defense in depth, so that errors missed by one will be caught by another.
 
-    Shows how several good programming practices fit together
-    to create defense in depth,
-    so that errors missed by one will be caught by another.
+Matthew Gentzkow and Jesse M. Shapiro. 2014: "Code and Data for the Social Sciences: A Practitioner’s Guide". University of Chicago mimeo, http://faculty.chicagobooth.edu/matthew.gentzkow/research/CodeAndData.pdf, last updated January 2014.
+:   An excellent description of how to move from doing data analysis with SAS and Excel to using maintainable scripts on well-organized data files in a reproducible way.
 
-*   Matthew Gentzkow and Jesse M. Shapiro. 2014:
-    "Code and Data for the Social Sciences: A Practitioner’s Guide".
-    University of Chicago mimeo,
-    http://faculty.chicagobooth.edu/matthew.gentzkow/research/CodeAndData.pdf,
-    last updated January 2014.
+Jo Erskine Hannay, Hans Petter Langtangen, Carolyn MacLeod, Dietmar Pfahl, Janice Singer, and Greg Wilson: "How Do Scientists Develop and Use Scientific Software?" *Proc. 2009 ICSE Workshop on Software Engineering for Computational Science and Engineering*, 2009.
+:   The largest study survey done of how scientists use computers in their research and how much time they spend doing so.
 
-    An excellent description of how to move from doing data analysis with SAS and Excel
-    to using maintainable scripts on well-organized data files in a reproducible way.
+William Stafford Noble: "A Quick Guide to Organizing Computational Biology Projects". *PLoS Computational Biology*, 5(7), 2009.
+:   How and why one scientist organizes his data and scripts.
 
-*   Jo Erskine Hannay, Hans Petter Langtangen, Carolyn MacLeod, Dietmar Pfahl, Janice Singer, and Greg Wilson:
-    "How Do Scientists Develop and Use Scientific Software?"
-    *Proc. 2009 ICSE Workshop on Software Engineering for Computational Science and Engineering*,
-    2009.
+Ethan P. White, Elita Baldridge, Zachary T. Brym, Kenneth J. Locey, Daniel J. McGlinn, and Sarah R. Supp: "Nine Simple Ways to Make It Easier to (Re)use Your Data." *PeerJ PrePrints*, 1:e7v2, 2012.
+:   Delivers exactly what the title promises: a straightforward set of practices that will make it easier for other scientists to use your data.
 
-    The largest study survey done of how scientists use computers in their research
-    and how much time they spend doing so.
+Greg Wilson, D. A. Aruliah, C. Titus Brown, Neil P. Chue Hong, Matt Davis, Richard T. Guy, Steven H. D. Haddock, Katy Huff, Ian M. Mitchell, Mark Plumbley, Ben Waugh, Ethan P. White, and Paul Wilson: "Best Practices for Scientific Computing". *PLoS Biology*, 12(1), 2014.
+:   Describes a set of best practices for scientific software development that have solid foundations in research and experience, and that improve scientists' productivity and the reliability of their software.
 
-*   William Stafford Noble:
-    "A Quick Guide to Organizing Computational Biology Projects".
-    *PLoS Computational Biology*,
-    5(7),
-    2009.
-
-    How and why one scientist organizes his data and scripts.
-
-*   Ethan P. White, Elita Baldridge, Zachary T. Brym, Kenneth J. Locey, Daniel J. McGlinn, and Sarah R. Supp:
-    "Nine Simple Ways to Make It Easier to (Re)use Your Data."
-    *PeerJ PrePrints*,
-    1:e7v2,
-    2012.
-
-    Delivers exactly what the title promises:
-    a straightforward set of practices that will make it easier for other scientists to use your data.
-
-*   Greg Wilson, D. A. Aruliah, C. Titus Brown, Neil P. Chue Hong, Matt Davis, Richard T. Guy, Steven H. D. Haddock, Katy Huff, Ian M. Mitchell, Mark Plumbley, Ben Waugh, Ethan P. White, and Paul Wilson:
-    "Best Practices for Scientific Computing".
-    *PLoS Biology*,
-    12(1),
-    2014.
-
-    Describes a set of best practices for scientific software development
-    that have solid foundations in research and experience,
-    and that improve scientists' productivity and the reliability of their software.
-
-*   Greg Wilson: "Software Carpentry: Lessons Learned".
-    *F1000 Research*, 3(62), 2014, [doi:10.12688/f1000research.3-62.v1](doi:10.12688/f1000research.3-62.v1).
-
-    Describes what we've learned about how to teach programming to scientists
-    over the last 15 years.
+Greg Wilson: "Software Carpentry: Lessons Learned". *F1000 Research*, 3(62), 2014, [doi:10.12688/f1000research.3-62.v1](doi:10.12688/f1000research.3-62.v1).
+:   Describes what we've learned about how to teach programming to scientists over the last 15 years.


### PR DESCRIPTION
Reorganizes the bibliography so that books appear before papers, and 'description' environments are used for bibliography entries and commentary.
