### PR TITLE
switch order of jekyll flags in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ INDEX = $(SITE)/index.html
 # having the output index.html file depend on all the page source
 # Markdown files triggers the desired build once and only once.
 $(INDEX) : ./index.html $(ALL_SRC) $(CONFIG) $(EXTRAS)
-	 jekyll -t build -d $(SITE)
+	 jekyll build -t -d $(SITE)
 
 #----------------------------------------------------------------------
 # Create all-in-one book version of notes.


### PR DESCRIPTION
In the current Makefile, `make site` fails with:

```
jekyll -t build -d _site
Invalid command. Use --help for more information
make: *** [_site/index.html] Error 1
```

 on Mac OS X, jekyll 2.0.3, ruby 2.1.2p95

switching the flag order allows it to run. I don't know if this causes problems with other versions of jekyll
