### PR TITLE
Added ./index.html as dependency for INDEX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ INDEX = $(SITE)/index.html
 # only does batch mode), and erases the SITE directory first, so
 # having the output index.html file depend on all the page source
 # Markdown files triggers the desired build once and only once.
-$(INDEX) : $(ALL_SRC) $(CONFIG) $(EXTRAS)
+$(INDEX) : ./index.html $(ALL_SRC) $(CONFIG) $(EXTRAS)
 	jekyll -t build -d $(SITE)
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
Not quite sure if actually not fixing something that ain't broken but when preparing a boocamp page, I often change 'index.htm'. In order to see if it's OK, I run 'make site' but since ./index.html is not a dependency for 'site' (in Makefile in gh-pages) nothing happens. In the 'master' branch such dependency exists. But the guidelines for creating new bootcamp repositories specify that instructors copy the contents of 'gh-pages'. So I guess it's the Makefile in gh-pages that should include the dependency too? 
