### PR TITLE
updated discussion list URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,5 +125,5 @@ FAQ
     <br/>
     Mail us at [admin@software-carpentry.org](mailto:admin@software-carpentry.org),
     come chat with us on [our IRC channel](irc://moznet/sciencelab),
-    or join our [discussion list](http://software-carpentry.org/contrib/discuss.html)
+    or join our [discussion list](http://software-carpentry.org/pages/discuss.html)
     and ask for help there.


### PR DESCRIPTION
Current URL for the discussion list takes the user to a 404 page

current: http://software-carpentry.org/contrib/discuss.html
proposed: http://software-carpentry.org/pages/discuss.html
