### PR TITLE
Fix issue when building book

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ EXTRAS = \
 # Principal target files
 INDEX = $(SITE)/index.html
 
+# All in one HTML target
+BOOK_HTML = $(SITE)/book.html
+
 # Convert from Markdown to HTML.  This builds *all* the pages (Jekyll
 # only does batch mode), and erases the SITE directory first, so
 # having the output index.html file depend on all the page source
@@ -96,6 +99,9 @@ BOOK_MD = ./book.md
 # image paths.
 $(BOOK_MD) : $(MOST_SRC) bin/make-book.py
 	   python bin/make-book.py $(MOST_SRC) > $@
+
+$(BOOK_HTML): $(BOOK_MD)
+	make -B site
 
 #----------------------------------------------------------------------
 # Targets.
@@ -125,8 +131,7 @@ clean : tidy
 ## book     : build the site including the all-in-one book.
 #  To do this, we simply create the book Markdown file then build
 #  with Jekyll as usual.
-book : $(BOOK_MD)
-	make site
+book : $(BOOK_HTML)
 
 ## install  : install on the server.
 install : $(INDEX)


### PR DESCRIPTION
## Short version

Try `make site` and after it `make book`. Jekyll need to run again but Make say it didn't.
## Long version

```
$ git rev-parse HEAD
a00cc35b4d39c7783296af79e2aa39fe53fe13a7
$ make site
jekyll -t build -d _site
Configuration file: /home/raniere/documents/software_carpentry/bc/_config.yml
            Source: /home/raniere/documents/software_carpentry/bc
       Destination: _site
      Generating... done.
$ make book
python bin/make-book.py intro.md team.md novice/shell/index.md novice/shell/00-intro.md novice/shell/01-filedir.md novice/shell/02-create.md novice/shell/03-pipefilter.md novice/shell/04-loop.md novice/shell/05-script.md novice/shell/06-find.md novice/git/index.md novice/git/00-intro.md novice/git/01-backup.md novice/git/02-collab.md novice/git/03-conflict.md novice/git/04-open.md novice/python/index.md novice/python/01-numpy.md novice/python/02-func.md novice/python/03-loop.md novice/python/04-cond.md novice/python/05-defensive.md novice/python/06-cmdline.md novice/sql/index.md novice/sql/01-select.md novice/sql/02-sort-dup.md novice/sql/03-filter.md novice/sql/04-calc.md novice/sql/05-null.md novice/sql/06-agg.md novice/sql/07-join.md novice/sql/08-create.md novice/sql/09-prog.md novice/extras/index.md novice/extras/01-branching.md novice/extras/02-review.md novice/extras/03-man.md novice/extras/04-permissions.md novice/extras/05-shellvar.md novice/extras/06-ssh.md novice/extras/07-exceptions.md novice/extras/08-numbers.md novice/extras/09-why.md novice/teaching/index.md  novice/teaching/01-general.md novice/teaching/02-shell.md novice/teaching/03-git.md novice/teaching/04-python.md novice/teaching/05-sql.md novice/ref/index.md  novice/ref/01-shell.md novice/ref/02-git.md novice/ref/03-python.md novice/ref/04-sql.md bib.md gloss.md rules.md LICENSE.md > book.md
make site
make[1]: Entering directory '/home/raniere/documents/software_carpentry/bc'
make[1]: Nothing to be done for 'site'.
make[1]: Leaving directory '/home/raniere/documents/software_carpentry/bc'
```
