### PR TITLE
Update template for book to rely on CSS

### DIFF
--- a/_layouts/book.html
+++ b/_layouts/book.html
@@ -8,6 +8,7 @@
     {% endif %}
     {% include header.html %}
     <link rel="stylesheet" type="text/css" href="{{page.root}}/css/lesson.css" />
+    <link rel="stylesheet" type="text/css" href="{{page.root}}/css/book.css" />
   </head>
   <body>
     <div class="container">
@@ -17,9 +18,10 @@
         <div class="span10 offset1">
 
 	  <div align="center">
-	    <h1 class="title">Software Carpentry</h1>
-	    <h2 class="subtitle">Volume 1: Basics</h2>
-	    <h2 class="subtitle">edited by Greg Wilson</h2>
+	    <h1 class="title">Software Carpentry
+              <span class="subtitle">Volume 1: Basics</span>
+              <span class="subtitle">edited by Greg Wilson</span>
+            </h1>
 	  </div>
 
 	  <div class="toc">

--- a/css/book.css
+++ b/css/book.css
@@ -1,0 +1,10 @@
+span.subtitle {
+  color: #030303;
+  display: block;
+  font-family: inherit;
+  font-size: 31.5px;
+  font-weight: bold;
+  line-height: 40px;
+  margin: 40px 0px 10px 0px;
+  text-rendering: optimizelegibility;
+}


### PR DESCRIPTION
Use h2 tag for "subtitle" will break any tool used to convert HTML
for another format. This commit replace h2 with span and rely on
CSS for have the same look.
