### PR TITLE
Fix headings for book

### DIFF
--- a/bin/make-book.py
+++ b/bin/make-book.py
@@ -72,7 +72,7 @@ def extract_title(filename, lines):
     return None
 
 def format_title(filename, title):
-    title = '## {0}'.format(title)
+    title = '## {0}\n'.format(title)
     f = os.path.split(filename)[-1]
     if f in ('index.md', 'intro.md'):
         return '\n'.join(['<div class="chapter" markdown="1">', title, '</div>'])


### PR DESCRIPTION
Some Markdown files start with

```

---
layout: lesson
root: .
title: TITLE

---
### SUBTITLE
```

When creating `book.md` it will have

```
## TITLE
### SUBTITLE
```

that is translate into HTML by Jekyll as

```
<h2>TITLE</h2>
<p>### SUBTITLE</p>
```

Change `make-book.py` to generate `book.md` having

```
## TITLE

### SUBTITLE
```

will fix this issue without side effect.

Thanks to @jduckles for reporting this issue.
