### PR TITLE
Add CSS for printing

### DIFF
--- a/css/swc.css
+++ b/css/swc.css
@@ -306,6 +306,27 @@ ul.checklist {
 
 /* Printing */
 @media print {
+  h1 {
+    font-size: 16pt;
+    line-height: 18pt;
+  }
+
+  h2,h3,h4,h5,h6 {
+    font-size: 12pt;
+    line-height: 13pt;
+  }
+
+  p,ul,ol,li,pre,code {
+    font-size: 8pt;
+    line-height: 9pt;
+  }
+
+  code {
+    padding: 0px;
+    border: 0px;
+    background: none;
+  }
+
   #github-ribbon {
     display: none;
   }


### PR DESCRIPTION
The CSS was add at our main CSS and remove from printing:
- Logo at header
- GitHub ribbon
- Footnote
