### PR TITLE
Modifying default layout of bootcamp pages to give instructors and helpers more prominence.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,8 @@ ALL_SRC = \
 # Other files that the site depends on.
 EXTRAS = \
        $(wildcard css/*.css) \
-       $(wildcard css/*/*.css)
+       $(wildcard css/*/*.css) \
+       $(wildcard _layouts/*.html)
 
 # Principal target files
 INDEX = $(SITE)/index.html

--- a/_layouts/bootcamp.html
+++ b/_layouts/bootcamp.html
@@ -19,9 +19,28 @@
           <div class="row-fluid">
             <div class="span10">
               <h2>{{page.venue}}</h2>
-              {% if page.address %}{{page.address}}<br/>{% endif %}
-              {{page.humandate}}
-              {% if page.humantime %}<br/>{{page.humantime}}{% endif %}
+	    </div>
+          </div>
+          <div class="row-fluid">
+	    <div class="span6">
+              <p>{{page.humandate}}</p>
+              <p>{% if page.humantime %}{{page.humantime}}{% endif %}</p>
+	    </div>
+	    <div class="span6">
+	      <p>
+		<strong>Instructors:</strong>
+		{% if page.instructor %}
+		{{page.instructor | join: ', ' %}}
+		{% else %}
+		to be announced.
+		{% endif %}
+	      </p>
+	      {% if page.helper %}
+	      <p>
+		<strong>Helpers:</strong>
+		{{page.helper | join: ', ' %}}
+	      </p>
+	      {% endif %}
 	    </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -50,22 +50,6 @@ contact: admin@software-carpentry.org
   and to apply what they have learned to their own research problems.
 </p>
 
-<!-- This block displays the instructors' names if they are available. -->
-{% if page.instructor %}
-<p>
-  <strong>Instructors:</strong>
-  {{page.instructor | join: ', ' %}}
-</p>
-{% endif %}
-
-<!-- This block displays the helpers' names if they are available. -->
-{% if page.helper %}
-<p>
-  <strong>Helpers:</strong>
-  {{page.helper | join: ', ' %}}
-</p>
-{% endif %}
-
 <!--
     Modify this block to reflect the target audience for your bootcamp.
     In particular, if it is only open to people from a particular institution,


### PR DESCRIPTION
1.  Moved list of instructors from `index.html` to `_layout/bootcamps.html` in order to put it in the header.
2.  Added a dependency in `Makefile` so that the site will rebuild when templates are changed.

Question: should the entire header well be moved into `./index.html` so that it's easier for bootcamp site authors to find and modify?  (We've found in the past that people find the `_includes` mechanism confusing.)

![screen shot 2014-06-25 at 6 45 52 am](https://cloud.githubusercontent.com/assets/911566/3384214/409472f8-fc56-11e3-83f6-6a1eef742e08.png)
