### PR TITLE
Fix image order in novice/git/03-conflict.md

### DIFF
--- a/novice/git/03-conflict.md
+++ b/novice/git/03-conflict.md
@@ -113,7 +113,11 @@ $ git commit -m "Adding a line in the temporary copy"
 ~~~
 {:class="out"}
 
-but Git won't let us push it to GitHub:
+giving us the following local repository state:
+
+<img src="img/git-after-second-conflicting-change.svg" alt="After Making Second (Conflicting) Change" />
+
+However, Git won't let us push this change in the temporary repository to GitHub:
 
 ~~~
 $ git push origin master
@@ -229,11 +233,11 @@ $ git commit -m "Merging changes from GitHub"
 ~~~
 {:class="out"}
 
-Our repositories now look like this:
+Our repositories now look like this after locally merging in the changes:
 
-<img src="img/git-after-second-conflicting-change.svg" alt="After Making Second (Conflicting) Change" />
+<img src="img/git-after-merging.svg" alt="After Merging Changes Locally" />
 
-so we push our changes to GitHub:
+so we push our merged changes to GitHub:
 
 ~~~
 $ git push origin master
@@ -252,7 +256,7 @@ To https://github.com/vlad/planets.git
 
 to get this:
 
-<img src="img/git-after-merging.svg" alt="After Merging Changes Locally" />
+<img src="img/git-after-pushing-merge.svg" alt="After Pushing The Merged Changes To GitHub" />
 
 Git keeps track of what we've merged with what,
 so we don't have to fix things by hand again


### PR DESCRIPTION
Corrects the order of the images in the Git Conflicts section. Addresses #573.
