### PR TITLE
Fix shell 05-script goostats option error

### DIFF
--- a/novice/shell/filesystem/users/nelle/north-pacific-gyre/2012-07-03/goostats
+++ b/novice/shell/filesystem/users/nelle/north-pacific-gyre/2012-07-03/goostats
@@ -9,4 +9,3 @@ done
 
 sleep 2
 head -3 $1 | cut -d , -f 1 | sort | uniq > $2
-


### PR DESCRIPTION
I added option handling to `goostats` with `getopts`.

`goostats` as added in #254 is returning an error when used with the options `-J 100 -r` as described in lesson 5. `-J` was being passed to head which returned invalid option. To fix this I added option handling with `getopts`. I assume the contents of `goostats` will not usually be looked at in a bootcamp. Coincidentally at 2014-07-28-stanford a student asked how to handle options. So it came in handy as an example :)
