### PR TITLE
Fix regex markdown

### DIFF
--- a/data/evil/notebook-3.txt
+++ b/data/evil/notebook-3.txt
@@ -1,0 +1,8 @@
+Date Site Evil(mvad)
+May 29 2010 (Hartnell) 1029.3
+May 30 2010 (Hartnell) 1119.2
+June 1 2010 (Hartnell) 1319.4
+May 29 2010 (Troughton) 1419.3
+May 30 2010 (Troughton) 1420.0
+June 1 2010 (Troughton) 1419.8
+

--- a/intermediate/regex/05-more-patterns.md
+++ b/intermediate/regex/05-more-patterns.md
@@ -25,7 +25,7 @@ characters: they have created groups.
 The way we solve this problem—i.e., the way we match a literal left
 parenthesis '(' or right parenthesis ')'—is to put a backslash in front
 of it. This is another example of an [escape
-sequence](glossary.html#escape-sequence): just as we use the
+sequence](../../gloss.html#escape-sequence): just as we use the
 two-character sequence `'\t'` in a string to represent a literal tab
 character, we use the two-character sequence `'\('` or `'\)'` in a
 regular expression to match the literal character '(' or ')'.
@@ -39,26 +39,16 @@ look at the various layers involved.
 
 Our program text—i.e., what's stored in our `.py` file—looks like this:
 
-    # find '()' in text
-    m = re.search('\\(\\)', text)
+~~~
+# find '()' in text
+m = re.search('\\(\\)', text)
     ⋮    ⋮    ⋮
+~~~
 
 The file has two backslashes, an open parenthesis, two backslashes, and
-a close parenthesis inside quotes:
-
-  ---- ---- --- ---- ---- ---
-  \\   \\   (   \\   \\   )
-  ---- ---- --- ---- ---- ---
-
-When Python reads that file in, it turns the two-character sequence
+a close parenthesis inside quotes. When Python reads that file in, it turns the two-character sequence
 '\\\\' into a single '\\' character in the string in memory. This is the
-first round of escaping.
-
-  ---- --- ---- ---
-  \\   (   \\   )
-  ---- --- ---- ---
-
-When we hand that string '\\(\\)' to the regular expression library, it
+first round of escaping. When we hand that string '\\(\\)' to the regular expression library, it
 takes the two-character sequence '\\(' and turns it into an arc in the
 finite state machine that matches a literal parenthesis:
 
@@ -131,7 +121,7 @@ pattern, it matches the end of the line rather than a literal '\$', so
 'temp\$' will match the string 'high-temp', but not the string
 'temperature'.
 
-Regular Expressions and Newlines
+### Regular Expressions and Newlines
 
 The full rule is slightly more complicated. By default, regular
 expressions act as if newline characters were the ends of records. For


### PR DESCRIPTION
Adds "in" and "out" code blocks to the regex lesson material. Also adds the third notebook containing some more 'evil' data.

Partially addresses issue #620. 03-operators.md still needs to be updated, but this should eventually be addressed in pull request #599.
