### PR TITLE
Fixed challenge in 05-defensive.ipynb where example function was not formatted correctly

### DIFF
--- a/novice/python/05-defensive.ipynb
+++ b/novice/python/05-defensive.ipynb
@@ -1,6 +1,7 @@
 {
  "metadata": {
-  "name": ""
+  "name": "",
+  "signature": "sha256:c5cd64a26d5ca61726fbbc8af79956c7e72c73052f37d0e93d6d201cbfd7bbc3"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -371,16 +372,16 @@
       " and for each one,\n",
       " give an example of input that will make that assertion fail.\n",
       " \n",
-      " ~~~\n",
-      " def running(values):\n",
-      " assert len(values) > 0\n",
-      " result = [values[0]]\n",
-      " for v in values[1:]:\n",
-      " assert result[-1] >= 0\n",
-      " result.append(result[-1] + v)\n",
-      " assert result[-1] >= result[0]\n",
-      " return result\n",
-      " ~~~"
+      "  ~~~python\n",
+      "  def running(values):\n",
+      "      assert len(values) > 0\n",
+      "      result = [values[0]]\n",
+      "      for v in values[1:]:\n",
+      "          assert result[-1] >= 0\n",
+      "          result.append(result[-1] + v)\n",
+      "          assert result[-1] >= result[0]\n",
+      "      return result\n",
+      "  ~~~"
      ]
     },
     {


### PR DESCRIPTION
Challenge #2 under the Assertions section of the novice/python/05-defensive.ipynb notebook contained a tilde-fenced code block in markdown that had lost any sort of indentation or syntax highlighting.
