### PR TITLE
Correct jekyll arg order for gh-pages Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ INDEX = $(SITE)/index.html
 # having the output index.html file depend on all the page source
 # Markdown files triggers the desired build once and only once.
 $(INDEX) : ./index.html $(ALL_SRC) $(CONFIG) $(EXTRAS)
-	 jekyll -t build -d $(SITE)
+	 jekyll build -t -d $(SITE)
 
 #----------------------------------------------------------------------
 # Create all-in-one book version of notes.


### PR DESCRIPTION
Local `make site` was failing because of incorrect jekyll arg order.  This line is correct in the master branch but is still broken here on gh-pages branch (which is what I pulled from to create the site repo as recommended in the setup guide).
