### PR TITLE
Modifying Mac git install directions

### DIFF
--- a/_includes/setup.html
+++ b/_includes/setup.html
@@ -171,7 +171,7 @@
       <strong>For OS X 10.8 and higher</strong>, install Git for Mac by downloading and running
 	  <a href="http://git-scm.com/downloads">the installer</a>.
       <strong>For older versions of OS X (10.5-10.7)</strong> use the most recent available
-      installer <a href="https://code.google.com/p/git-osx-installer/downloads/list">available
+      installer for your OS <a href="https://code.google.com/p/git-osx-installer/downloads/list">available
       here</a>. Use the Leopard installer for 10.5 and the Snow Leopard
       installer for 10.6-10.7.
     </p>


### PR DESCRIPTION
The first line of the Mac git directions says to download git, but this only works for OSX 10.8
and higher. This fix makes clear that this is only for OSX 10.8 and
encourages students to read the second line to find the correct download for 
versions for 10.5 - 10.7

My editor automatically strips trailing whitespace, that is the change in line 247.
