### PR TITLE
Fixes from cambridge

### DIFF
--- a/novice/python/02-func.ipynb
+++ b/novice/python/02-func.ipynb
@@ -1678,6 +1678,38 @@
     },
     {
      "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "One final note about functions - in python, you don't have to return anything\n",
+      "if you don't want to.\n",
+      "\n",
+      "For example:"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def say_hello(name):\n",
+      "    print 'Hello', name\n",
+      "    \n",
+      "say_hello('Sally')"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "output_type": "stream",
+       "stream": "stdout",
+       "text": [
+        "Hello Sally\n"
+       ]
+      }
+     ],
+     "prompt_number": 33
+    },
+    {
+     "cell_type": "markdown",
      "metadata": {
       "cell_tags": [
        "challenges"

--- a/novice/python/02-func.md
+++ b/novice/python/02-func.md
@@ -813,6 +813,21 @@ That's why we don't have to provide `fname=` for the filename,
 but *do* have to provide `delimiter=` for the second parameter.
 
 
+One final note about functions - in python, you don't have to return anything
+if you don't want to.
+
+For example:
+
+
+<pre class="in"><code>def say_hello(name):
+    print &#39;Hello&#39;, name
+    
+say_hello(&#39;Sally&#39;)</code></pre>
+
+<div class="out"><pre class='out'><code>Hello Sally
+</code></pre></div>
+
+
 <div class="challenges" markdown="1">
 #### Challenges
 

--- a/novice/shell/04-loop.md
+++ b/novice/shell/04-loop.md
@@ -477,7 +477,7 @@ Describe in words what the following loop does.
 ~~~
 for how in frog11 prcb redig
 do
-    $how -limit 0.01 NENE01729B.txt
+    $how NENE01729A.txt NENE01729B.txt NENE01729C.txt
 done
 ~~~
 </div>

--- a/novice/teaching/03-git.md
+++ b/novice/teaching/03-git.md
@@ -95,6 +95,13 @@ We close with material on licensing because:
     CVS and Subversion are now seen as legacy systems,
     and Mercurial isn't nearly as widely used in the sciences right now.
 
+*   The last challenge in the git conflicts lesson asks learners what happens
+    if there is a conflict in an image file. Some learners may try this out
+    in their repositories and it will not be obvious how to resolve the 
+    conflict. They can use `git checkout --ours /path/to/image` to keep the
+    local version of the image, or `git checkout --theirs /path/to/image` to
+    keep the remote version.
+
 #### Text Editor
 
 We suggest instructors and students use `nano` as the text editor for this lessons because:


### PR DESCRIPTION
This PR contains three (hopefully) atomic commits that address three separate issues which came up during the bootcamp at Cambridge University on August 26th/27th. I'm happy to submit a new PR without one of them if people disagree with some subset of the changes.

#### 1. Commit *d90338a*

The last challenge in the loops lesson from `novice/shell` asks learners to figure out what the following loop does:

```bash
for how in frog11 prcb redig
do
     $how -limit 0.01 NENE01729B.txt
done
```

Many of the learners asked what the `-limit` flag does, which of course depends on which of our imaginary programs we are calling in this particular loop. I think that the presence of a flag here doesn't make much sense, so I changed the parameters to be three file names, which I think should be less confusing.

#### 2. Commit *3926b4d*

The last challenge in the conflicts lesson from `novice/git` asks learners what git does when there is a conflict in an image. Many of the learners tried this out themselves and were then unable to resolve the conflict. This commit adds instructions to the teaching guide for git on how to resolve these conflicts (or at least how I did it, someone with a higher level of git-fu might have a better suggestion)

#### 3. Commit *8e222dd*

The last challege in the functions lesson from `novice/python` asks learners to make a function that plots three graphs. Since at this point learners have only encountered functions that return something, many of them were having problems returning inappropriate things at the end of their functions. I just added a little note right before the challenge that functions don't have to return anything.