### PR TITLE
Adding support for home pages that immediately redirect to other sites.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,9 @@ site : $(INDEX)
 check :
 	@python bin/swc_index_validator.py ./index.html
 
+## redirect : check that a redirection index.html page is properly formatted.
+	@python bin/swc_index_validator.py -r ./index.html
+
 ## clean    : clean up all generated files.
 clean : tidy
 	rm -rf $(SITE)

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -1,0 +1,16 @@
+---
+---
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Software Carpentry: {{page.venue}}</title>
+    <meta name="venue" content="{{page.venue}}" />
+    <meta name="date" content="{{page.humandate}}" />
+    <meta name="startdate" content="{{page.startdate}}" />
+    <meta name="enddate" content="{{page.enddate}}" />
+    <meta http-equiv="refresh" content="0; url={{page.redirect}}" />
+  </head>
+  <body>
+    <p>Redirecting to <a href="{{page.redirect}}">{{page.redirect}}</a>.</p>
+  </body>
+</html>

--- a/redirect-index.html
+++ b/redirect-index.html
@@ -1,0 +1,18 @@
+---
+layout: redirect
+root: .
+venue: Euphoric State University
+address: 123 College Street, Euphoria
+country: United-States
+humandate: Feb 17-18, 2020
+humantime: 9:00 am - 4:30 pm
+startdate: 2020-06-17
+enddate: 2020-06-18
+latlng: 41.7901128,-87.6007318
+registration: restricted
+instructor: ["Grace Hopper", "Alan Turing"]
+helper: []
+contact: admin@software-carpentry.org
+lessons: []
+redirect: http://example.com
+---


### PR DESCRIPTION
Some sites would like to use their own home pages for workshops rather than GitHub pages.
However, all of our website machinery expects to harvest workshop information from GitHub.
The (hacked) solution is to allow people to create a GitHub repository containing a home page
that immediately redirects to their own site.  To do this, we:
1. Create a new layout called `redirect.html` containing a YAML header key `redirect`.
2. Tell them to `mv redirect-index.html index.html` and then edit the header.
3. Modify the `bin/swc_index_validator.py` script to take a `-r` flag, and then check for redirection if that flag is present.

I'm sure a cleaner implementation of all of this is possible...
