### PR TITLE
Add headers at Markdown blank example

### DIFF
--- a/misc/blank-markdown.md
+++ b/misc/blank-markdown.md
@@ -16,6 +16,12 @@ title: Title of Lesson
 
 </div>
 
+### First section
+
+Our sections start at `<h3>` or `###` (in Markdown).
+
+### Second section
+
 Write paragraphs of text here.
 When you need to show input, output, and errors,
 put a triple tilde `~~~` before and after like this:


### PR DESCRIPTION
@gvwilson I don't remember why our sections use `h3`. Do you remember?
