### PR TITLE
Correct definition of the fahr_to_kelvin function in 02-func.ipynb 

### DIFF
--- a/novice/python/02-func.ipynb
+++ b/novice/python/02-func.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:2f81f3414a0b7db89be2606011c0a2a9487f2dfe3aa826af1cc11570e41ffc69"
+  "signature": "sha256:ac842e2471495d61397b584148040477439c46cde00201700cb8455f2e43be86"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -76,7 +76,7 @@
      "collapsed": false,
      "input": [
       "def fahr_to_kelvin(temp):\n",
-      "    return ((temp - 32) * (5/9)) + 273.15"
+      "    return ((temp - 32) * (5./9)) + 273.15"
      ],
      "language": "python",
      "metadata": {


### PR DESCRIPTION
Added a decimal point to the `fahr_to_kelvin` function in `02-func.ipynb` so that it works on Python 2.x.
