### PR TITLE
rename "Miscellaneous" header

### DIFF
--- a/_includes/setup.html
+++ b/_includes/setup.html
@@ -299,7 +299,7 @@
   </div>
 </div>
 
-<h3>Miscellaneous</h3>
+<h3>All operating systems</h3>
 
 <div class="row-fluid">
   <div class="span6">


### PR DESCRIPTION
At our last workshop, helpers unfamiliar with the setup found confusing the naming "Miscellaneous" for the SQL plugin that needed to installed for everybody. Here I suggest "All operating systems" instead, but I'm open to other suggestions.
