### PR TITLE
info on how to display the menu bar

### DIFF
--- a/_includes/setup.html
+++ b/_includes/setup.html
@@ -328,9 +328,16 @@
 	Restart Firefox when prompted.
       </li>
       <li>
-	Select "SQLite Manager" from the "Tools" menu.
+	To check that the plugin installed correctly, select "SQLite Manager" from the "Tools" menu.
       </li>
     </ul>
+    <p>
+      In newer versions of Firefox, the menu bar isn't always displayed. To make
+      it appear, use the <code>Alt</code> key next to the space bar on your
+      keyboard, or consult
+      the <a href="https://support.mozilla.org/en-US/kb/what-happened-to-the-file-edit-and-view-menus">support
+      page</a> from Firefox for additional help.
+    </p>
 {% endif %}
   </div>
   <div class="span6">


### PR DESCRIPTION
At our last workshop, some participants were confused by the last sentence of the instructions for the plugin installation: they didn't know what to do after starting the plugin. I added additional information to indicate it was just a check to see that the plugin installed successfully.

Most people were however unable to start the plugin before coming to the workshop, as newer versions of firefox hide by default the menu bar. I added instructions on how to make it appear.
