### PR TITLE
Remove duplicate challenge in the second notebook of the novice SQL lesson

### DIFF
--- a/novice/sql/02-sort-dup.ipynb
+++ b/novice/sql/02-sort-dup.ipynb
@@ -201,15 +201,6 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "#### Challenges\n",
-      "\n",
-      "1.  Write a query that selects distinct dates from the `Site` table."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
       "As we mentioned earlier,\n",
       "database records are not stored in any particular order.\n",
       "This means that query results aren't necessarily sorted,\n",

--- a/novice/sql/02-sort-dup.md
+++ b/novice/sql/02-sort-dup.md
@@ -107,10 +107,6 @@ it's important to remember that rows aren't actually ordered:
 they're just displayed that way.
 
 
-#### Challenges
-
-1.  Write a query that selects distinct dates from the `Site` table.
-
 
 As we mentioned earlier,
 database records are not stored in any particular order.


### PR DESCRIPTION
The challenge appears twice, once in the middle of the lesson, and again at the end. Furthermore, the one in the middle mentions the wrong table for the exercise (should be "Visited" instead of "Site"). The one in the middle is removed, to be consistent with the rest of the lessons, where challenges appear always at the end.