### PR TITLE
Mention comments at MATLAB lesson

### DIFF
--- a/novice/matlab/02-loop.md
+++ b/novice/matlab/02-loop.md
@@ -133,7 +133,7 @@ print -dpng "average.png"
 {:class="in"}
 
 You might have noticed that we described what we want 
-out code to do using the `%`-sign.
+our code to do using the `%`-sign.
 This is another plus of writing scripts: you can comment
 your code to make it easier to understand when you come
 back to it after a while. 


### PR DESCRIPTION
- fixed some minor issues
- short paragraph on commenting

I think we should introduce commenting as early as possible. @ashwinsrnth, should we have the 'publish'-section is this lesson?
I would also suggest that we change 'i' to 'idx', since 'i' is the imaginary unit in Matlab. 
