### PR TITLE
Avoiding 'i' as a variable in MATLAB materials

### DIFF
--- a/novice/matlab/02-loop.md
+++ b/novice/matlab/02-loop.md
@@ -483,7 +483,7 @@ our files:
 
 ~~~
 for idx = 1:12
-    file_name = sprintf('inflammation-%d.csv', i);
+    file_name = sprintf('inflammation-%d.csv', idx);
     disp(file_name);
 end
 ~~~
@@ -517,7 +517,7 @@ loop, `i` starts by referring to
 the value 1. So, when MATLAB executes the command
 
 ~~~
-file_name = sprintf('inflammation-%d.csv', i);
+file_name = sprintf('inflammation-%d.csv', idx);
 ~~~
 
 it substitutes the `%d` in the template `inflammation-%d.csv`, with the
@@ -534,7 +534,7 @@ right, we have to modify our template:
 
 ~~~
 for idx = 1:12
-    file_name = sprintf('inflammation-%02d.csv', i);
+    file_name = sprintf('inflammation-%02d.csv', idx);
     disp(file_name);
 end
 ~~~
@@ -569,8 +569,8 @@ We're now ready to modify `analyze.m` to process multiple data files:
 for idx = 1:3
 
     % Generate strings for file and image names:
-    file_name = sprintf('inflammation-%02d.csv', i);
-    img_name = sprintf ('patient_data-%02d.png', i);
+    file_name = sprintf('inflammation-%02d.csv', idx);
+    img_name = sprintf ('patient_data-%02d.png', idx);
 
     patient_data = csvread(file_name);
     ave_inflammation = mean(patient_data, 1);

--- a/novice/matlab/04-cond.md
+++ b/novice/matlab/04-cond.md
@@ -96,7 +96,7 @@ We can also combine tests, using `&&` (and) and `||` (or). `&&`
 is true if both tests are true:
 
 ~~~
-if ((j > 0) && (-1 > 0))
+if ((1 > 0) && (-1 > 0))
     disp('both parts are true');
 else
     disp('one part is not true');

--- a/novice/matlab/analyze.m
+++ b/novice/matlab/analyze.m
@@ -1,8 +1,8 @@
-for i = 1:3
+for idx = 1:3
     
     % Generate strings for file and image names:
-    file_name = sprintf('inflammation-%02d.csv', i);
-    img_name = sprintf ('patient_data-%02d.png', i);
+    file_name = sprintf('inflammation-%02d.csv', idx);
+    img_name = sprintf ('patient_data-%02d.png', idx);
 
     patient_data = csvread(file_name);
     ave_inflammation = mean(patient_data, 1);


### PR DESCRIPTION
- replaced ‘i’ with ‘idx’ in lesson 2
- replaced ‘i’ with ‘j’ in lesson 4

'i' is used as the imaginary unit in MATLAB. I think it's better style to avoid using it as a variable, too. 

@ashwinsrnth, in lesson 4, is it possible that 'i' was meant to be '1'?
