### PR TITLE
Add _includes to site dependencies.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,8 @@ ALL_SRC = \
 EXTRAS = \
        $(wildcard css/*.css) \
        $(wildcard css/*/*.css) \
-       $(wildcard _layouts/*.html)
+       $(wildcard _layouts/*.html) \
+       $(wildcard _includes/*.html)
 
 # Principal target files
 INDEX = $(SITE)/index.html


### PR DESCRIPTION
Found my site was not rebuilding when I changed the setup instructions included from _includes/setup.html.
