### PR TITLE
Small fixes in "General advice"

### DIFF
--- a/novice/teaching/01-general.md
+++ b/novice/teaching/01-general.md
@@ -11,14 +11,6 @@ see [this wiki page](https://github.com/swcarpentry/bc/wiki/Configuration-Proble
 
 #### Teaching Notes
 
-*   For workshops that extend over more than two days
-    (e.g., four afternoons spread over two weeks),
-    it's a good idea to email the learners at the end of each day with a summary of what was taught
-    (with links to the relevant online notes).
-    This allows absent learners to catch up before the next session,
-    and is also a great opportunity to present the lessons of the day
-    in the context of the entire workshop.
-
 *   Point learners at [http://software-carpentry.org/v5/](http://software-carpentry.org/v5/),
     which is the permanent home of the current learning materials,
     and at [http://software-carpentry.org/v4/](http://software-carpentry.org/v4/),


### PR DESCRIPTION
There was duplication of text and misspelling. The first section "For workshops that extend..." is repeated further down.

Regards,
Olav
