### PR TITLE
Adding setup instructions for Git on Mac OS X 10.8.3

### DIFF
--- a/_includes/setup.html
+++ b/_includes/setup.html
@@ -167,13 +167,19 @@
 {% if page.lessons contains 'Git' %}
     <h4>Git</h4>
     <p>
-
       <strong>For OS X 10.8 and higher</strong>, install Git for Mac by downloading and running
-	  <a href="http://git-scm.com/downloads">the installer</a>.
+      <a href="http://git-scm.com/downloads">the installer</a>.
       <strong>For older versions of OS X (10.5-10.7)</strong> use the most recent available
       installer for your OS <a href="https://code.google.com/p/git-osx-installer/downloads/list">available
       here</a>. Use the Leopard installer for 10.5 and the Snow Leopard
       installer for 10.6-10.7.
+    </p>
+    <p>
+      <strong>Note:</strong> some users have reported problems on Mac OS X 10.8.3:
+      Git installs, and <code>git --help</code> runs,
+      but anything that touches the filesystem (e.g., <code>git init .</code>) fails.
+      In that case,
+      please try installing <a href="https://mac.github.com/">GitHub for Mac</a> instead.
     </p>
 {% endif %}
   </div>


### PR DESCRIPTION
In response to failures at various workshops.
