### PR TITLE
Fixing instructions for contributors during transition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,17 @@
 Contributing New Material
 =========================
 
+> **Note**
+>
+> We are currently reorganizing our repositories.
+> We hope to complete work by the end of November 2014,
+> but in the interim:
+>
+> 1. Please check with us before creating pull requests against this repository ---
+>    we may point you at a new one.
+> 2. If you *do* create pull requests against this repository,
+>    please use the `gh-pages` branch rather than the `master` branch.
+
 Software Carpentry is an open source project,
 and we welcome contributions of all kinds:
 new and improved lessons,
@@ -63,20 +74,24 @@ please mail us at
 Given a choice between you creating content or wrestling with Git,
 we'd rather have you doing the former.
 
-The GitHub workflow looks like this:
+Our GitHub workflow looks like this:
 
 1.  Fork the `swcarpentry/bc` repository on GitHub.
 
 2.  Clone that repository to your own machine.
 
-3.  Create a branch from `master` for your changes.
+3.  Create a branch from `gh-pages` for your changes.
     Give your branch a meaningful name,
     such as `fixing-typos-in-novice-shell-lesson`
     or `adding-tutorial-on-visualization`.
 
 4.  Make your changes, commit them, and push them to your repository on GitHub.
 
-5.  Send a pull request to the `master` branch of `[swcarpentry/bc](http://github.com/swcarpentry/bc)`.
+5.  Send a pull request to the `gh-pages` branch of `[swcarpentry/bc](http://github.com/swcarpentry/bc)`.
+
+**Note**: as noted at the top of this page,
+please create pull requests against the `gh-pages` branch
+rather than the `master` branch.
 
 If it is easier for you to send them to us some other way,
 please mail us at

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 Software Carpentry Workshops
 ============================
 
+> **Note**
+>
+> We are currently reorganizing our repositories.
+> We hope to complete work by the end of November 2014,
+> but in the interim:
+>
+> 1. Please check with us before creating pull requests against this repository ---
+>    we may point you at a new one.
+> 2. If you *do* create pull requests against this repository,
+>    please use the `gh-pages` branch rather than the `master` branch.
+
 The `bc` repository is the starting point for creating your own workshop website:
 it contains a template for your workshop's home page,
 and also hosts the shared lesson materials we have developed.


### PR DESCRIPTION
1. Tell people to check with us before PR'ing this repo.
2. Tell people to PR against `gh-pages` instead of `master`.
