### PR TITLE
Added a Next Workflow on the git section pages

### DIFF
--- a/novice/git/00-intro.md
+++ b/novice/git/00-intro.md
@@ -50,3 +50,5 @@ and because of a hosting site called [GitHub](http://github.com).
 No matter which version control system you use,
 the most important thing to learn is not the details of their more obscure commands,
 but the workflow that they encourage.
+
+[Next Lesson : A Better Kind of Backup](01-backup.html)

--- a/novice/git/01-backup.md
+++ b/novice/git/01-backup.md
@@ -927,3 +927,5 @@ git init     # make the beta sub-directory a Git repository
 
 Why is it a bad idea to do this?
 </div>
+
+[Next Lesson : Collaborating](02-collab.html)

--- a/novice/git/02-collab.md
+++ b/novice/git/02-collab.md
@@ -311,3 +311,5 @@ push those changes to GitHub,
 and then look at the [timestamp](../../gloss.html#timestamp) of the change on GitHub.
 How does GitHub record times, and why?
 </div>
+
+[Next Lesson : Conflicts](03-conflict.html)

--- a/novice/git/03-conflict.md
+++ b/novice/git/03-conflict.md
@@ -311,3 +311,5 @@ What does Git do
 when there is a conflict in an image or some other non-textual file
 that is stored in version control?
 </div>
+
+[Next Lesson : Open Science](04-open.html)


### PR DESCRIPTION
I figured that it would be easier for the instructors to navigate in the workshop content if there was a Next page link at the bottom of each page.

I just did it for the git section pages. If you tell me that it's useful, I'll do it for every section.

Also, I don't know much about Jekyll, but : 
1) Is there a way to right align this without HTML? (If not, I guess that I'll do it with HTML)
2) Maybe it would be worth it to add a previous link also, what do you think?
3) Finally, if there's a way to automatically generate the link from the neighboorhod pages, that would be cool (so that if the title of the page change, the link would change automatically). But I don't know if it's feasible.

Tell me what you think !
