### PR TITLE
Documented some undocumented build requirements (PyYAML and IPython >=1.1.0)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,13 @@ you can run the same checks using:
 python bin/swc_index_validator.py ./index.html
 ~~~
 
-This checks that the workshop's instructors are listed,
+This requires that you have the PyYAML package installed, which you can do using `pip`:
+
+~~~
+$ pip install PyYAML
+~~~
+
+Running `make check` checks that the workshop's instructors are listed,
 that a contact email address has been set up,
 and so on.
 

--- a/ipynb.mk
+++ b/ipynb.mk
@@ -20,6 +20,7 @@ all : ipynb
 #----------------------------------------------------------------------
 
 # Templates.
+# This template uses IPython.nbconvert.filters.string2url which requires IPython's version >= 1.1.0
 IPYNB_TPL = _templates/ipynb.tpl
 
 # IPython Notebooks.  Add patterns here to convert notebooks stored in


### PR DESCRIPTION
I was slowed down but a couple of requirements that I didn't see stated in the contributor's guide. The PyYAML package is used by swc_index_validator.py (i.e. what make check performs).

Also I had an old version of IPython (Gentoo still masks everything > 1.0), and got this _warning_ when running `make ipynb`:

``` python
[NbConvertApp] WARNING | Unexpected exception loading template: _templates/ipynb.tpl
Traceback (most recent call last):
  File "/usr/lib64/python2.7/site-packages/IPython/nbconvert/exporters/exporter.py", line 230, in _load_template
    self.template = self.environment.get_template(try_name)
  File "/usr/lib64/python2.7/site-packages/jinja2/environment.py", line 791, in get_template
    return self._load_template(name, self.make_globals(globals))
  File "/usr/lib64/python2.7/site-packages/jinja2/environment.py", line 765, in _load_template
    template = self.loader.load(self, name, globals)
  File "/usr/lib64/python2.7/site-packages/jinja2/loaders.py", line 395, in load
    return loader.load(environment, name, globals)
  File "/usr/lib64/python2.7/site-packages/jinja2/loaders.py", line 125, in load
    code = environment.compile(source, name, filename)
  File "/usr/lib64/python2.7/site-packages/jinja2/environment.py", line 554, in compile
    self.handle_exception(exc_info, source_hint=source)
  File "/usr/lib64/python2.7/site-packages/jinja2/environment.py", line 742, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "./_templates/ipynb.tpl", line 21, in <module>
    {%- block data_svg -%}<img src="../../{{ output.svg_filename | path2url }}">{%- endblock data_svg -%}
TemplateAssertionError: no filter named 'path2url'
```

I tracked down the version of IPython in which path2url was introduced: 1.1.0 and noted that in the makefile. Not sure if that's the best place to document it. Feedback welcome.
