### PR TITLE
Avoid using names like vectors and matrices when indicating numpy arrays.

### DIFF
--- a/novice/python/01-numpy.ipynb
+++ b/novice/python/01-numpy.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:bdd5075bd4a75df8ed67c3124b0664471edfc1bfe6110ddcf01e68e156bcb9bb"
+  "signature": "sha256:a21e2675f1ccc5577b5ca5d0fe5a2789889c9682f9da8f4b9714aed2bbcc77c2"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -95,7 +95,7 @@
       "even more live in the [libraries](../../gloss.html#library) they are used to build.\n",
       "\n",
       "In order to load our inflammation data,\n",
-      "we need to [import](../../gloss.html#import) a library called NumPy. In general you should use this library if you want to do fancy things with numbers, especially if you have matrices. We can load NumPy using:"
+      "we need to [import](../../gloss.html#import) a library called NumPy. In general you should use this library if you want to do fancy things with numbers. We can load NumPy using:"
      ]
     },
     {
@@ -591,7 +591,7 @@
       "cell_tags": []
      },
      "source": [
-      "If we want to get a single value from the matrix,\n",
+      "If we want to get a single value from the array,\n",
       "we must provide an [index](../../gloss.html#index) in square brackets,\n",
       "just as we do in math:"
      ]
@@ -663,7 +663,7 @@
       "> What may also surprise you is that when Python displays an array,\n",
       "> it shows the element with index `[0, 0]` in the upper left corner\n",
       "> rather than the lower left.\n",
-      "> This is consistent with the way mathematicians draw matrices,\n",
+      "> This is consistent with the way mathematicians draw matrices (2d-arrays),\n",
       "> but different from the Cartesian coordinates.\n",
       "> The indices are (row, column) instead of (column, row) for the same reason, \n",
       "> which can be confusing when plotting data."
@@ -1146,7 +1146,7 @@
       "cell_tags": []
      },
      "source": [
-      "The expression `(40,)` tells us we have an N&times;1 vector,\n",
+      "The expression `(40,)` tells us we have a array of length 40,\n",
       "so this is the average inflammation per day for all patients.\n",
       "If we average across axis 1, we get:"
      ]


### PR DESCRIPTION
Without a discussion of matrices as a 2d-array and a vector as a 1d-array in the context of general nd-arrays the language of array, matrix, and vector may be somewhat confusing. As this language is rarely used in the text it is easily avoided or clarified.

In addition, expected matrix behavior (Hadamard product versus matrix product) and the differences between the np.array and np.matrix classes may be confused here.

At line 1149 the language (N X 1) would seem to indicate a 2d column vector in the numpy notation not a 1d row vector. 