### PR TITLE
Add short section on vector recycling to novice R loop supplement

### DIFF
--- a/novice/r/03-supp-loops-in-depth.Rmd
+++ b/novice/r/03-supp-loops-in-depth.Rmd
@@ -29,7 +29,7 @@ analyze <- function(filename) {
 ```
 
 ```{r files}
-filenames <- list.files(pattern = "csv")
+filenames <- list.files(pattern = "inflammation.+\\.csv")
 ```
 
 #### Vectorized operations
@@ -61,6 +61,34 @@ Instead, `+` is a *vectorized* function which can operate on entire vectors at o
 ```{r}
 res2 <- a + b
 all.equal(res, res2)
+```
+
+##### Vector recycling
+
+When performing vector operations in R, it is important to know about *recycling*. If you perform an operation on two or more vectors of unequal length, R will recycle elements of the shorter vector(s) to match the longest vector.  For example:
+
+```{r}
+a <- 1:10
+b <- 1:5
+a + b
+```
+
+The elements of `a` and `b` are added together starting from the first element of both vectors. When R reaches the end of the shorter vector `b`, it starts again at the first element of `b` and contines until it reaches the last element of the longest vector `a`.  This behaviour may seem crazy at first glance, but it is very useful when you want to perform the same operation on every element of a vector. For example, say we want to multiply every element of our vector `a` by 5:
+
+```{r}
+a <- 1:10
+b <- 5
+a * b
+```
+
+Remember there are no scalars in R, so `b` is actually a vector of length 1; in order to add its value to every element of `a`, it is *recycled* to match the length of `a`.
+
+When the length of the longer object is a multiple of the shorter object length (as in our example above), the recycling occurs silently. When the longer object length is not a multiple of the shorter object length, a warning is given:
+
+```{r}
+a <- 1:10
+b <- 1:7
+a + b
 ```
 
 #### `for` or `apply`?

--- a/novice/r/03-supp-loops-in-depth.md
+++ b/novice/r/03-supp-loops-in-depth.md
@@ -26,7 +26,7 @@ In that lesson, we introduced how to run a custom function, `analyze`, over mult
 }</code></pre>
 
 
-<pre class='in'><code>filenames <- list.files(pattern = "csv")</code></pre>
+<pre class='in'><code>filenames <- list.files(pattern = "inflammation.+\\.csv")</code></pre>
 
 #### Vectorized operations
 
@@ -64,6 +64,52 @@ all.equal(res, res2)</code></pre>
 
 
 <div class='out'><pre class='out'><code>[1] TRUE
+</code></pre></div>
+
+##### Vector recycling
+
+When performing vector operations in R, it is important to know about *recycling*. If you perform an operation on two or more vectors of unequal length, R will recycle elements of the shorter vector(s) to match the longest vector.  For example:
+
+
+<pre class='in'><code>a <- 1:10
+b <- 1:5
+a + b</code></pre>
+
+
+
+<div class='out'><pre class='out'><code> [1]  2  4  6  8 10  7  9 11 13 15
+</code></pre></div>
+
+The elements of `a` and `b` are added together starting from the first element of both vectors. When R reaches the end of the shorter vector `b`, it starts again at the first element of `b` and contines until it reaches the last element of the longest vector `a`.  This behaviour may seem crazy at first glance, but it is very useful when you want to perform the same operation on every element of a vector. For example, say we want to multiply every element of our vector `a` by 5:
+
+
+<pre class='in'><code>a <- 1:10
+b <- 5
+a * b</code></pre>
+
+
+
+<div class='out'><pre class='out'><code> [1]  5 10 15 20 25 30 35 40 45 50
+</code></pre></div>
+
+Remember there are no scalars in R, so `b` is actually a vector of length 1; in order to add its value to every element of `a`, it is *recycled* to match the length of `a`.
+
+When the length of the longer object is a multiple of the shorter object length (as in our example above), the recycling occurs silently. When the longer object length is not a multiple of the shorter object length, a warning is given:
+
+
+<pre class='in'><code>a <- 1:10
+b <- 1:7
+a + b</code></pre>
+
+
+
+<div class='out'><pre class='out'><code>Warning in a + b: longer object length is not a multiple of shorter object
+length
+</code></pre></div>
+
+
+
+<div class='out'><pre class='out'><code> [1]  2  4  6  8 10 12 14  9 11 13
 </code></pre></div>
 
 #### `for` or `apply`?
@@ -118,7 +164,7 @@ system.time(avg2 <- analyze2(filenames))</code></pre>
 
 
 <div class='out'><pre class='out'><code>   user  system elapsed 
-  0.044   0.000   0.045 
+  0.045   0.002   0.047 
 </code></pre></div>
 
 Note how we add a new column to `out` at each iteration?
@@ -143,7 +189,7 @@ system.time(avg3 <- analyze3(filenames))</code></pre>
 
 
 <div class='out'><pre class='out'><code>   user  system elapsed 
-  0.056   0.004   0.057 
+  0.045   0.001   0.046 
 </code></pre></div>
 
 In this simple example there is little difference in the compute time of `analyze2` and `analyze3`.


### PR DESCRIPTION
This adds a short section on how R recycles vectors when dealing with vectors of unequal length. In order to render the .md file I also had to change the pattern in the list.files call on line 32, as there are more than just the original inflammation csv's that match the "csv" pattern.

This PR is the "small fix" submitted as part of the final assignment for the Software Carpentry instructor training.