### PR TITLE
Fixed md code markup for python code samples in intermediate/python/03-qa.md.

### DIFF
--- a/intermediate/python/03-qa.md
+++ b/intermediate/python/03-qa.md
@@ -148,7 +148,7 @@ AssertionError                            Traceback (most recent call last)
       3     x0, y0, x1, y1 = rect
 ----&gt; 4     assert x0 &lt; x1, &#39;Invalid X coordinates&#39;
       5     assert y0 &lt; y1, &#39;Invalid Y coordinates&#39;
-      6 
+      6
 
 AssertionError: Invalid X coordinates</code></pre></div>
 
@@ -176,10 +176,10 @@ AssertionError                            Traceback (most recent call last)
 ----&gt; 1 print normalize_rectangle( (0.0, 0.0, 5.0, 1.0) )
 
 &lt;ipython-input-21-fdb49ef456c2&gt; in normalize_rectangle(rect)
-     15 
+     15
      16     assert 0 &lt; upper_x &lt;= 1.0, &#39;Calculated upper X coordinate invalid&#39;
 ---&gt; 17     assert 0 &lt; upper_y &lt;= 1.0, &#39;Calculated upper Y coordinate invalid&#39;
-     18 
+     18
      19     return (0, 0, upper_x, upper_y)
 
 AssertionError: Calculated upper Y coordinate invalid</code></pre></div>
@@ -229,17 +229,16 @@ that this bit is tricky.
 2.  Explain in words what the assertions in this code check,
     and for each one,
     give an example of input that will make that assertion fail.
-    
-    ```
-    def running(values):
-        assert len(values) > 0
-        result = [values[0]]
-        for v in values[1:]:
-            assert result[-1] >= 0
-            result.append(result[-1] + v)
-        assert result[-1] >= result[0]
-        return result
-    ```
+
+<pre class="in"><code>def running(values):
+    assert len(values) > 0
+    result = [values[0]]
+    for v in values[1:]:
+        assert result[-1] >= 0
+        result.append(result[-1] + v)
+    assert result[-1] >= result[0]
+    return result
+</code></pre>
 
 ## Exceptions
 
@@ -257,15 +256,13 @@ here's a small piece of code that tries to read parameters and a grid from two s
 and reports an error if either goes wrong:
 
 
-```python
-try:
+<pre class="in"><code>try:
     params = read_params(param_file)
     grid = read_grid(grid_file)
 except:
     log.error('Failed to read input file(s)')
     sys.exit(ERROR)
-```
-
+</code></pre>
 
 We join the normal case and the error-handling code using the keywords `try` and `except`.
 These work together like `if` and `else`:
@@ -335,8 +332,7 @@ For example,
 here's some code to calculate the entropy at each point in a grid:
 
 
-```python
-try:
+<pre class="in"><code>try:
     params = read_params(param_file)
     grid = read_grid(grid_file)
     entropy = lee_entropy(params, grid)
@@ -345,7 +341,7 @@ except IOError:
     report_error_and_exit('IO error')
 except ArithmeticError:
     report_error_and_exit('Arithmetic error')
-```
+</code></pre>
 
 
 Python tries to run the four functions inside the `try` as normal.
@@ -368,8 +364,7 @@ We can do better if we capture and hang on to the object that Python creates
 to record information about the error:
 
 
-```python
-try:
+<pre class="in"><code>try:
     params = read_params(param_file)
     grid = read_grid(grid_file)
     entropy = lee_entropy(params, grid)
@@ -378,8 +373,7 @@ except IOError as err:
     report_error_and_exit('Cannot read/write' + err.filename)
 except ArithmeticError as err:
     report_error_and_exit(err.message)
-```
-
+</code></pre>
 
 If something goes wrong in the `try`,
 Python creates an exception object,
@@ -402,24 +396,21 @@ if this code can't read the grid file that the user has asked for,
 it creates a default grid instead:
 
 
-```python
-try:
+<pre class="in"><code>try:
     grid = read_grid(grid_file)
 except IOError:
     grid = default_grid()
-```
-
+</code></pre>
 
 Other programmers would explicitly test for the grid file,
 and use `if` and `else` for control flow:
 
 
-```python
-if file_exists(grid_file):
+<pre class="in"><code>if file_exists(grid_file):
     grid = read_grid(grid_file)
 else:
     grid = default_grid()
-```
+</code></pre>
 
 
 It's mostly a matter of taste,
@@ -441,8 +432,7 @@ they don't have to be handled immediately.
 Take another look at this code:
 
 
-```python
-try:
+<pre class="in"><code>try:
     params = read_params(param_file)
     grid = read_grid(grid_file)
     entropy = lee_entropy(params, grid)
@@ -451,7 +441,7 @@ except IOError as err:
     report_error_and_exit('Cannot read/write' + err.filename)
 except ArithmeticError as err:
     report_error_and_exit(err.message)
-```
+</code></pre>
 
 
 The four lines in the `try` block are all function calls.
@@ -487,8 +477,7 @@ for example,
 is a function that reads a grid and checks its consistency:
 
 
-```python
-def read_grid(grid_file):
+<pre class="in"><code>def read_grid(grid_file):
     '''Read grid, checking consistency.'''
 
     data = read_raw_data(grid_file)
@@ -497,7 +486,7 @@ def read_grid(grid_file):
     result = normalize_grid(data)
 
     return result
-```
+</code></pre>
 
 
 The `raise` statement creates a new exception with a meaningful error message.
@@ -515,13 +504,13 @@ which is outside the scope of these lessons.
 ### Challenges
 
 1.  Modify the program below so that it prints three lines of output.
-    ```
-    try:
-        for number in [-1, 0, 1]:
-            print 1.0/number
-    except ZeroDivisionError:
-        print 'whoops'
-    ```
+
+<pre class="in"><code>try:
+    for number in [-1, 0, 1]:
+        print 1.0/number
+except ZeroDivisionError:
+    print 'whoops'
+</code></pre>
 
 ## The Limits to Testing
 
@@ -546,49 +535,44 @@ consider a function that checks whether a character strings contains only the le
 These four tests clearly aren't sufficient:
 
 
-```python
-assert is_all_bases('A')
+<pre class="in"><code>assert is_all_bases('A')
 assert is_all_bases('C')
 assert is_all_bases('G')
 assert is_all_bases('T')
-```
+</code></pre>
 
 
 because this version of `is_all_bases` passes them:
 
 
-```python
-def is_all_bases(bases):
+<pre class="in"><code>def is_all_bases(bases):
     return True
-```
+</code></pre>
 
 
 Adding these tests isn't enough:
 
 
-```python
-assert not is_all_bases('X')
+<pre class="in"><code>assert not is_all_bases('X')
 assert not is_all_bases('Y')
 assert not is_all_bases('Z')
-```
+</code></pre>
 
 
 because this version still passes:
 
 
-```python
-def is_all_bases(bases):
+<pre class="in"><code>def is_all_bases(bases):
     return bases[0] in 'ACGT'
-```
+</code></pre>
 
 
 We can add yet more tests:
 
 
-```python
-assert is_all_bases('ACGCGA')
+<pre class="in"><code>assert is_all_bases('ACGCGA')
 assert not is_all_bases('CGAZ')
-```
+</code></pre>
 
 
 but no matter how many we have,
@@ -792,10 +776,9 @@ To see how,
 consider this test case for our rectangle area function:
 
 
-```python
-def test_inverted_rectangle():
+<pre class="in"><code>def test_inverted_rectangle():
     assert rectangle_area([1, 5, 5, 2]) == -12.0
-```
+</code></pre>
 
 
 Is that test correct?
@@ -805,16 +788,14 @@ and do they have negative area?
 Or should the test be:
 
 
-```python
-def test_inverted_rectangle():
-    try:
-        rectangle_area([1, 5, 5, 2])
-        assert False, 'Function did not raise exception for invalid rectangle'
-    except ValueError:
-        pass # rectangle_area failed with the expected kind of exception
-    except Exception:
-        assert False, 'Function did not raise correct kind of exception for invalid rectangle'
-```
+<pre class="in"><code>def test_inverted_rectangle():try:
+    rectangle_area([1, 5, 5, 2])
+    assert False, 'Function did not raise exception for invalid rectangle'
+except ValueError:
+    pass # rectangle_area failed with the expected kind of exception
+except Exception:
+    assert False, 'Function did not raise correct kind of exception for invalid rectangle'
+</code></pre>
 
 
 The logic in this second version may take a moment to work out,
@@ -825,10 +806,9 @@ if it's given a rectangle whose upper edge is below or to the left of its lower 
 Here's another test case that can help us design our software:
 
 
-```python
-def test_zero_width():
+<pre class="in"><code>def test_zero_width():
     assert rectangle_area([2, 1, 2, 8]) == 0
-```
+</code></pre>
 
 
 We might decide that rectangles with negative areas aren't allowed,
@@ -878,19 +858,19 @@ trying it a few times helps you learn how to design functions and programs that 
 ### Challenges
 
 1.  Write a function called `something` that passes the following unit tests:
-    ```
-    def test_empty():
-        assert something([]) == []
-    
-    def test_single_value():
-        assert something(['a']) == []
-    
-    def test_two_values():
-        assert something(['a', 'b']) == [('a', 'b')]
-    
-    def test_three_values():
-        assert something(['a', 'b', 'c']) == [('a', 'b'), ('a', 'c'), ('b', 'c')]
-    ```
+
+<pre class="in"><code>def test_empty():
+    assert something([]) == []
+
+def test_single_value():
+    assert something(['a']) == []
+
+def test_two_values():
+    assert something(['a', 'b']) == [('a', 'b')]
+
+def test_three_values():
+    assert something(['a', 'b', 'c']) == [('a', 'b'), ('a', 'c'), ('b', 'c')]
+</code></pre>
 
 ## Next Steps
 


### PR DESCRIPTION
Fixed md code markup for python code samples in intermediate/python/03-qa.md. Replaced triple ``` with pre + code tags.
