### PR TITLE
Two suggested fixes for the unix shell loops lesson 

### DIFF
--- a/novice/shell/04-loop.md
+++ b/novice/shell/04-loop.md
@@ -17,7 +17,7 @@ title: Loops
 
 Wildcards and tab completion are two ways to reduce typing (and typing mistakes).
 Another is to tell the shell to do something over and over again.
-Suppose we have several hundred genome data files named `basilisk.dat`, `unicorn.dat`, and so on. In this example, we'll use the `creatures` directory which only has two example files, but the principles can be applied to many many more files at once. We would like to modify the files, but also save a version of the original files, and rename them as `original-basilisk.dat` and `original-unicorn.dat`.
+Suppose we have several hundred genome data files named `basilisk.dat`, `unicorn.dat`, and so on. In this example, we'll use the `creatures` directory which only has two example files, but the principles can be applied to many many more files at once. We would like to modify the files, but also save a version of the original files and rename them as `original-basilisk.dat` and `original-unicorn.dat`.
 We can't use:
 
 ~~~
@@ -424,6 +424,16 @@ do
     ls *.dat
 done
 ~~~
+
+Now, what is the output of:
+
+~~~
+for datafile in *.dat
+do
+	ls $datafile
+done
+~~~
+
 </div>
 
 <div class="challenge" markdown="1">


### PR DESCRIPTION
For my final lesson to become a SWC instructor, I reviewed the unix shell loops lesson and am suggesting two small fixes. The first, is simply to clarify the explanation of the example of why loops are sometimes more useful than wildcards for repeating commands. The second is an addition to the first excercise at the end of the lesson. I think the point of the lesson was to reinforce the difference between using wildcards within for loops versus using $variable_name. Only an example of what happens if you use a wild-card is given. I added an example of using $variable_name so that the learners can clearly examine the differences between these two outputs.
